### PR TITLE
PATCH 對 <svg>/<iframe> 段落直接通過比對 (#68)

### DIFF
--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -216,6 +216,14 @@ function stripMarkdownTitleLine(markdown: string): string {
 
 /** 段落比對鍵：用於 LCS 判斷「同一段」是否相同（講者 + 內容） */
 function normalizeSectionComparableContent(input: string): string {
+	// Issue #68：含 <svg>...</svg> 或 <iframe>...</iframe> 的段落，無論內容是否相同
+	// 一律視為同段（給同 section_id），D1 內容仍以新值覆寫
+	if (/<svg\b[^>]*>[\s\S]*?<\/svg\s*>/i.test(input)) {
+		return '<svg>';
+	}
+	if (/<iframe\b[^>]*>[\s\S]*?<\/iframe\s*>/i.test(input)) {
+		return '<iframe>';
+	}
 	return input
 		// 先把常見換行型標記轉成空白，再移除其餘 HTML 標記
 		.replace(/<br\s*\/?>/gi, ' ')

--- a/test/upload_markdown.spec.ts
+++ b/test/upload_markdown.spec.ts
@@ -19,9 +19,19 @@ type SpeechIndexRow = {
 	alternate_filename?: string | null;
 };
 
+type OldSection = {
+	filename: string;
+	section_id: number;
+	previous_section_id: number | null;
+	next_section_id: number | null;
+	section_speaker: string | null;
+	section_content: string;
+};
+
 function createUploadEnv(options?: {
 	currentAlternateFilename?: string | null;
 	extraSpeechIndexRows?: SpeechIndexRow[];
+	oldSections?: OldSection[];
 }) {
 	const operations: PreparedStatement[] = [];
 	const deletedKeys: string[] = [];
@@ -40,7 +50,7 @@ function createUploadEnv(options?: {
 		...(options?.extraSpeechIndexRows ?? [])
 	];
 
-	const oldSections = [
+	const oldSections: OldSection[] = options?.oldSections ?? [
 		{
 			filename: 'demo-speech',
 			section_id: 100,
@@ -306,6 +316,116 @@ describe('upload_markdown PATCH', () => {
 				`${CACHE_KEY_VERSION}/example.com/speeches`
 			])
 		);
+	});
+
+	// Issue #68：含 <svg>/<iframe> 的段落不論內容差異一律配對為同段
+	it('preserves section_id for <svg> blocks even when inner content changes', async () => {
+		const env = createUploadEnv({
+			oldSections: [
+				{
+					filename: 'demo-speech',
+					section_id: 100,
+					previous_section_id: null,
+					next_section_id: 101,
+					section_speaker: null,
+					section_content: '<p>Alpha</p>'
+				},
+				{
+					filename: 'demo-speech',
+					section_id: 101,
+					previous_section_id: 100,
+					next_section_id: null,
+					section_speaker: null,
+					section_content: '<svg width="100"><text>OLD</text></svg>'
+				}
+			]
+		});
+
+		const body = [
+			'# Demo Speech',
+			'Alpha',
+			'',
+			'<svg width="200"><text>NEW</text></svg>'
+		].join('\n');
+
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({ filename: 'demo-speech', markdown: body })
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			success: true,
+			filename: 'demo-speech',
+			sectionsCount: 2,
+			insertedCount: 0,
+			updatedCount: 2,
+			deletedCount: 0
+		});
+
+		const updates = env.__operations.filter((stmt) => stmt.sql.startsWith('UPDATE speech_content'));
+		expect(updates.map((stmt) => stmt.args[5])).toEqual([100, 101]);
+		const svgUpdate = updates.find((stmt) => stmt.args[5] === 101);
+		expect(svgUpdate?.args[3]).toContain('width="200"');
+		expect(svgUpdate?.args[3]).toContain('NEW');
+	});
+
+	it('preserves section_id for <iframe> blocks even when src changes', async () => {
+		const env = createUploadEnv({
+			oldSections: [
+				{
+					filename: 'demo-speech',
+					section_id: 100,
+					previous_section_id: null,
+					next_section_id: 101,
+					section_speaker: null,
+					section_content: '<p>Alpha</p>'
+				},
+				{
+					filename: 'demo-speech',
+					section_id: 101,
+					previous_section_id: 100,
+					next_section_id: null,
+					section_speaker: null,
+					section_content: '<iframe src="https://old.example.com"></iframe>'
+				}
+			]
+		});
+
+		const body = [
+			'# Demo Speech',
+			'Alpha',
+			'',
+			'<iframe src="https://new.example.com"></iframe>'
+		].join('\n');
+
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({ filename: 'demo-speech', markdown: body })
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			success: true,
+			filename: 'demo-speech',
+			sectionsCount: 2,
+			insertedCount: 0,
+			updatedCount: 2,
+			deletedCount: 0
+		});
+
+		const updates = env.__operations.filter((stmt) => stmt.sql.startsWith('UPDATE speech_content'));
+		const iframeUpdate = updates.find((stmt) => stmt.args[5] === 101);
+		expect(iframeUpdate?.args[3]).toContain('https://new.example.com');
+		expect(iframeUpdate?.args[3]).not.toContain('old.example.com');
 	});
 });
 


### PR DESCRIPTION
## Summary
- `normalizeSectionComparableContent` 加入 SVG/iframe 哨兵，PATCH 比對遇到含 `<svg>...</svg>` 或 `<iframe>...</iframe>` 的段落時，不論內容差異一律視為同段，沿用舊 `section_id`
- D1 內容仍以新版覆寫（透過 `assignPatchedSections` 既有流程：`output.push({ ...newSection, section_id: oldSection.section_id })`）
- 擴充 `createUploadEnv` 測試 helper 接受自訂 `oldSections`，新增兩個 PATCH 測試覆蓋 svg width/text 變更與 iframe src 變更場景

## Test plan
- [x] `npx vitest run test/upload_markdown.spec.ts` — 5 passed
- [x] `npx vitest run test/upload_markdown_patch.spec.ts test/upload_markdown_edges.spec.ts test/upload_markdown_coverage_final.spec.ts` — 20 passed（無回歸）
- [ ] `npm run typecheck` 有兩筆 satori/resvg-wasm 既有錯誤（main 分支同樣存在），與此 PR 無關

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)