### PR TITLE
fix(md): Unknown 講者改 blockquote、中文姓名用全形冒號

### DIFF
--- a/src/api/md.ts
+++ b/src/api/md.ts
@@ -187,10 +187,23 @@ function an2md(anXml: string): string {
 	const merged: string[] = [];
 	let prevShowAs: string | null = null;
 	for (const { showAs, content } of blocks) {
-		if (showAs === prevShowAs) {
+		if (showAs === 'Unknown') {
+			const quoted = content
+				.split('\n\n')
+				.map((p) =>
+					p
+						.split('\n')
+						.map((l) => (l.length === 0 ? '>' : `> ${l}`))
+						.join('\n')
+				)
+				.join('\n>\n');
+			merged.push(quoted);
+			prevShowAs = showAs;
+		} else if (showAs === prevShowAs) {
 			merged.push(content);
 		} else {
-			merged.push(`### ${showAs}: \n\n${content}`);
+			const colon = /\p{Script=Han}$/u.test(showAs) ? '：' : ': ';
+			merged.push(`### ${showAs}${colon}\n\n${content}`);
 			prevShowAs = showAs;
 		}
 	}

--- a/test/md.spec.ts
+++ b/test/md.spec.ts
@@ -19,4 +19,31 @@ describe('md conversion', () => {
 		expect(md).not.toContain('&#39;');
 		expect(md).not.toContain('&apos;');
 	});
+
+	it('uses fullwidth ：for speaker names ending in Han characters', () => {
+		const md = __test__.an2md(`<akomaNtoso>
+			<TLCPerson id="p1" showAs="唐鳳"/>
+			<speech by="#p1"><p>大家好</p></speech>
+		</akomaNtoso>`);
+		expect(md).toContain('### 唐鳳：');
+		expect(md).not.toContain('### 唐鳳: ');
+	});
+
+	it('keeps halfwidth ": " for non-Han speaker names', () => {
+		const md = __test__.an2md(`<akomaNtoso>
+			<TLCPerson id="p1" showAs="TonyQ"/>
+			<speech by="#p1"><p>Hello</p></speech>
+		</akomaNtoso>`);
+		expect(md).toContain('### TonyQ: ');
+	});
+
+	it('renders Unknown speaker as blockquote without ### header', () => {
+		const md = __test__.an2md(`<akomaNtoso>
+			<TLCPerson id="u" showAs="Unknown"/>
+			<speech by="#u"><p>（開場簡報）</p><p>連結略</p></speech>
+		</akomaNtoso>`);
+		expect(md).not.toContain('### Unknown');
+		expect(md).toContain('> （開場簡報）');
+		expect(md).toContain('> 連結略');
+	});
 });


### PR DESCRIPTION
## Summary

- `an2md()` 將 `Unknown` 講者段落輸出為 blockquote（`> ...`），不再產生 `### Unknown: ` 標題。
- 講者名稱以漢字結尾時，標題冒號改為全形 `：`（無尾隨空白）；其他名稱維持半形 `: `。
- 對應新增 3 條單元測試（共 384 測試通過）。

Closes #80

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test`（42 files / 384 tests pass）
- [ ] 部署後抽樣比對 `.md` 匯出格式