### PR TITLE
fix(deploy): 防止 wrangler 靜默失敗導致樣板永遠 stale

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
 	"private": true,
 	"scripts": {
 		"deploy": "npm run deploy:search",
-		"deploy:assets": "npm run build:cache-version && npm run build:views && npm run build:assets && wrangler deploy",
-		"deploy:search": "npm run build:cache-version && npm run build:views && npm run build:assets && npm run build:search && wrangler deploy",
+		"deploy:assets": "npm run assert:node && npm run build:cache-version && npm run build:views && npm run build:assets && npx wrangler deploy && npm run verify:deploy",
+		"deploy:search": "npm run assert:node && npm run build:cache-version && npm run build:views && npm run build:assets && npm run build:search && npx wrangler deploy && npm run verify:deploy",
 		"dev": "npm run build:views && wrangler dev --remote",
+		"assert:node": "tsx --tsconfig scripts/tsconfig.json scripts/assert-node.ts",
+		"verify:deploy": "tsx --tsconfig scripts/tsconfig.json scripts/verify-deploy.ts",
 		"build:cache-version": "tsx --tsconfig scripts/tsconfig.json scripts/generate-cache-version.ts",
 		"start": "npm run dev",
 		"build:views": "tsx --tsconfig scripts/tsconfig.json scripts/build-views.ts",

--- a/scripts/assert-node.ts
+++ b/scripts/assert-node.ts
@@ -1,0 +1,12 @@
+// Refuse to run deploy scripts under bun — wrangler deploy silently fails
+// (exit code 0, no upload) when invoked through bun's runtime. Must use node.
+const isBun =
+	typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined' ||
+	typeof (process.versions as { bun?: string }).bun === 'string';
+
+if (isBun) {
+	console.error('✗ Refusing to deploy under bun runtime.');
+	console.error('  wrangler deploy silently fails under bun (exit 0, no upload).');
+	console.error('  Use: npm run deploy:search   (or: npx wrangler deploy)');
+	process.exit(1);
+}

--- a/scripts/verify-deploy.ts
+++ b/scripts/verify-deploy.ts
@@ -1,0 +1,51 @@
+// After wrangler deploy, poll /version until it returns the CACHE_KEY_VERSION
+// we just shipped. If it doesn't match after a few retries, the deploy silently
+// failed and the old worker is still live — fail the script so CI/operator sees it.
+import { CACHE_KEY_VERSION } from '../src/cacheKeyVersion';
+
+const url = process.env.VERIFY_URL ?? 'https://archive.tw/version';
+const maxAttempts = 6;
+const delayMs = 2000;
+
+async function fetchVersion(): Promise<string | null> {
+	const res = await fetch(`${url}?_=${Date.now()}`, {
+		cache: 'no-store',
+		headers: { 'Cache-Control': 'no-cache' }
+	});
+	if (!res.ok) {
+		console.warn(`  HTTP ${res.status} from ${url}`);
+		return null;
+	}
+	const body = (await res.json()) as { version?: string };
+	return body.version ?? null;
+}
+
+async function main() {
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			const got = await fetchVersion();
+			if (got === CACHE_KEY_VERSION) {
+				console.log(`✓ Deploy verified: ${url} returns ${CACHE_KEY_VERSION}`);
+				return;
+			}
+			console.warn(`  attempt ${attempt}/${maxAttempts}: got ${got ?? 'null'}, want ${CACHE_KEY_VERSION}`);
+		} catch (err) {
+			console.warn(`  attempt ${attempt}/${maxAttempts}: ${err}`);
+		}
+		if (attempt < maxAttempts) {
+			await new Promise((r) => setTimeout(r, delayMs));
+		}
+	}
+
+	console.error(`✗ Deploy verification FAILED.`);
+	console.error(`  ${url} did not return ${CACHE_KEY_VERSION} after ${maxAttempts} attempts.`);
+	console.error(`  The worker is likely still running an older version — wrangler deploy`);
+	console.error(`  silently did nothing (common failure mode under bun runtime).`);
+	console.error(`  Retry with: npx wrangler deploy`);
+	process.exit(1);
+}
+
+main().catch((err) => {
+	console.error('verify-deploy crashed:', err);
+	process.exit(1);
+});

--- a/src/cacheKeyVersion.ts
+++ b/src/cacheKeyVersion.ts
@@ -1,4 +1,4 @@
 // Auto-generated at deploy time by scripts/generate-cache-version.ts
 // Do not edit manually — this is overwritten on every deploy.
-export const CACHE_KEY_VERSION = 'v-a2dee13';
+export const CACHE_KEY_VERSION = 'v-4e85627';
 export const OLD_CACHE_VERSIONS: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,7 @@ async function staticFirstMiddleware(c: any, next: () => Promise<void>) {
 		|| pathname === '/search-index-manifest.json'
 		|| pathname === '/sections-dump.json'
 		|| pathname === '/stats.json'
+		|| pathname === '/version'
 	) return next();
 	if (
 		pathname === '/' ||
@@ -797,6 +798,10 @@ app.get('/sections-dump.json', async (c) => {
 		},
 	});
 });
+
+app.get('/version', (c) =>
+	c.json({ version: CACHE_KEY_VERSION }, 200, { 'Cache-Control': 'no-store' })
+);
 
 // D1 APIs
 app.get('/api/speech_index.json', (c) => speechIndex(c));

--- a/test/ssr_routes.spec.ts
+++ b/test/ssr_routes.spec.ts
@@ -367,13 +367,21 @@ describe('SSR /:filename', () => {
 		const html = await res.text();
 		expect(html).toContain('Flat');
 		expect(env.__r2Store.has(`${CACHE_KEY_VERSION}/example.com/2026-flat`)).toBe(true);
+		expect(html).toContain('<meta property="og:image" content="https://archive.tw/og/2026-flat.png">');
+		expect(html).toContain('<meta property="og:image:width" content="1200">');
+		expect(html).not.toMatch(/apple-touch-icon-152x152\.png/);
+		expect(html).not.toMatch(/https:\/\/sayit\.archive\.tw/);
 	});
 
 	it('renders a nested speech list page', async () => {
 		const env = createSsrEnv(flatResolver);
 		const { res } = await request('/2026-nested', env);
 		expect(res.status).toBe(200);
-		expect(await res.text()).toContain('Nested');
+		const html = await res.text();
+		expect(html).toContain('Nested');
+		expect(html).toContain('<meta property="og:image" content="https://archive.tw/og/2026-nested.png">');
+		expect(html).not.toMatch(/apple-touch-icon-152x152\.png/);
+		expect(html).not.toMatch(/https:\/\/sayit\.archive\.tw/);
 	});
 
 	it('returns 500 when speech meta lookup throws', async () => {
@@ -530,6 +538,9 @@ describe('SSR /:filename/:nest_filename', () => {
 		expect(res.status).toBe(200);
 		const html = await res.text();
 		expect(html).toContain('Alpha');
+		expect(html).toContain('<meta property="og:image" content="https://archive.tw/og/2026-nested.png">');
+		expect(html).not.toMatch(/apple-touch-icon-152x152\.png/);
+		expect(html).not.toMatch(/https:\/\/sayit\.archive\.tw/);
 	});
 
 	it('returns 500 when nested meta query throws', async () => {
@@ -630,6 +641,15 @@ describe('Static search/stats endpoints', () => {
 		const { res } = await request('/sections-dump.json', envHit);
 		expect(res.status).toBe(200);
 		expect(await res.text()).toContain('"id":1');
+	});
+
+	it('serves /version with CACHE_KEY_VERSION and no-store cache-control', async () => {
+		const env = createSsrEnv(() => ({ success: true, results: [] }));
+		const { res } = await request('/version', env);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Cache-Control')).toBe('no-store');
+		const body = (await res.json()) as { version: string };
+		expect(body.version).toBe(CACHE_KEY_VERSION);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Cherry-pick \`c2ad3a5\`〈Guard deploys against silent wrangler failures〉from \`origin/codex/enforce-statement-coverage\`（原本沒進 main，導致同樣的 cache 問題反覆發生）
- 新增 \`GET /version\` → 回 \`{ version: CACHE_KEY_VERSION }\`，no-store
- 新增 \`assert-node.ts\`：deploy 前若偵測到 bun runtime 就 \`exit 1\`
- 新增 \`verify-deploy.ts\`：部署後輪詢 \`/version\`，沒拿到剛 build 的版號就 fail
- \`deploy:assets\` / \`deploy:search\` 改成 \`assert:node → build → npx wrangler deploy → verify:deploy\`
- 補一條 og:image 回歸測試

確認 https://archive.tw/version 目前回 404，代表線上 worker 是 c2ad3a5 之前的版本，從 4/24 之後的部署全部都靜默沒生效。樣板修改沒辦法上線，stale HTML 一直被 R2 cache 住。

## Test plan

- [x] \`npm run typecheck\` — pass
- [x] \`npx vitest run test/ssr_routes.spec.ts\` — 46 passed（其餘 vitest pool 啟動失敗為主機環境，main 也一樣）
- [ ] Merge 後請務必在 **node**（不是 bun）跑 \`npm run deploy:search\`，新的 \`assert:node\` + \`verify:deploy\` 會把任何 silent failure 直接擋下

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)