### PR TITLE
fix(stats): 修正首頁「篇發言」與「場會議」數字顛倒

### DIFF
--- a/src/search/runtime.ts
+++ b/src/search/runtime.ts
@@ -95,7 +95,7 @@ export async function markSpeechDeletedInSearch(
 }
 
 export async function syncSearchStats(c: Context<ApiEnv>): Promise<void> {
-	const [speechesRow, speakersRow, sectionsRow] = await Promise.all([
+	const [sectionsRow, speakersRow, speechesRow] = await Promise.all([
 		c.env.DB.prepare('SELECT COUNT(*) AS count FROM speech_index').first<CountRow>(),
 		c.env.DB.prepare('SELECT COUNT(*) AS count FROM speakers').first<CountRow>(),
 		c.env.DB.prepare('SELECT COUNT(*) AS count FROM speech_content').first<CountRow>()

--- a/test/search_runtime.spec.ts
+++ b/test/search_runtime.spec.ts
@@ -35,9 +35,9 @@ function createBucket(initial: Record<string, string> = {}) {
 
 function createContext(bucket: any, countRows: { speeches?: number; speakers?: number; sections?: number } = {}) {
 	const firstFor = (sql: string) => {
-		if (sql.includes('FROM speech_index')) return { count: countRows.speeches ?? 3 };
+		if (sql.includes('FROM speech_index')) return { count: countRows.sections ?? 3 };
 		if (sql.includes('FROM speakers')) return { count: countRows.speakers ?? 2 };
-		if (sql.includes('FROM speech_content')) return { count: countRows.sections ?? 5 };
+		if (sql.includes('FROM speech_content')) return { count: countRows.speeches ?? 5 };
 		return null;
 	};
 	return {


### PR DESCRIPTION
`syncSearchStats` 把 `speech_index`（場會議, ~2,018 筆）的 count 寫到
`stats.speeches`，把 `speech_content`（篇發言, ~397,877 筆）的 count
寫到 `stats.sections`，剛好顛倒。

把 destructure 順序改成 `[sectionsRow, speakersRow, speechesRow]`，
維持原本 SQL 查詢順序不動，stats 物件即可拿到正確對應。同步調整
test/search_runtime.spec.ts 的 mock 對應。

Closes #127