### PR TITLE
test(sectionUtils): 補 checkMonotonic 稀疏陣列 null guard 測試

### DIFF
--- a/test/sectionUtils.spec.ts
+++ b/test/sectionUtils.spec.ts
@@ -29,6 +29,10 @@ describe('sectionUtils', () => {
 			expect(checkMonotonic([mk(1, null, 2), mk(1, 1, 3)])).toBe(false);
 			expect(checkMonotonic([mk(2, null, 3), mk(1, 2, null)])).toBe(false);
 		});
+		it('稀疏陣列含 hole 時為 false（防禦性 null guard）', () => {
+			const sparse = [mk(1, null, 2), undefined, mk(3, 2, null)] as unknown as SectionLike[];
+			expect(checkMonotonic(sparse)).toBe(false);
+		});
 		it('section_id 遞增但鏈結順序不一致時為 false（PATCH 中段插入情境）', () => {
 			// section_id ASC = [10, 11, 12, 99]，但鏈結順序是 10 → 11 → 99 → 12
 			// 99 是後來 PATCH 插在 11 與 12 之間的新段落，section_id 大但顯示位置在中段


### PR DESCRIPTION
## Summary

- 補一筆 `checkMonotonic` 的稀疏陣列測試，覆蓋 `src/utils/sectionUtils.ts:28` 的防禦性 null guard
- 此 guard 是 9897c46 加進來的，但沒測試打到，導致 `bun run test:coverage` 卡在該檔 97.72% 不過 100% 門檻
- 本次補測後 statements / lines / functions 均回到 100%（437/437 tests pass）

PR #128 已把 stats 顛倒的修正合進 main，這支分支 rebase 後只剩這支補測 commit。

Closes #129

## Test plan

- [x] `bun run test:coverage`：44 files / 437 tests pass，statement coverage 100%
- [ ] CI on PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qdo1N6pL8ZNCcKouWQRWJ7)_