### PR TITLE
fix(upload_markdown): allocate fresh ids when inserting after a sub-section anchor

### DIFF
--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -426,7 +426,6 @@ function appendInsertedSections(
 	if (newInserts.length > 99) throw new Error('Too many inserted sections in a single gap (max 99)');
 
 	const fallbackBase = output.length > 0 ? output[output.length - 1].section_id : baseIdHint ?? 0;
-	let nextCandidate = isSubSectionId(fallbackBase) ? fallbackBase + 1 : fallbackBase * 100 + 1;
 
 	const allocateFresh = (): number => {
 		while (usedIds.has(freshIdRef.value)) freshIdRef.value += 1;
@@ -435,6 +434,24 @@ function appendInsertedSections(
 		return id;
 	};
 
+	// When the anchor is already a "large" sub-section id, the base*100+N / base+1
+	// locality scheme has no safe room: those candidates fall *below* the global
+	// MAX(section_id) counter and walk straight into ids owned by OTHER speeches,
+	// hitting "UNIQUE constraint failed: speech_content.section_id" on INSERT (503).
+	// loadConflictingSubSectionIds only pre-blocks [min*100+1, max*100+99], which for
+	// a sub-section anchor is a far-away ~10-digit window that misses the real
+	// collision zone near base+1. For those anchors, allocate guaranteed-unique
+	// fresh ids (globalMax+1…) instead; small-id anchors keep the locality scheme.
+	if (isSubSectionId(fallbackBase)) {
+		for (const insertSection of newInserts) {
+			const chosenId = allocateFresh();
+			usedIds.add(chosenId);
+			output.push({ ...insertSection, section_id: chosenId });
+		}
+		return;
+	}
+
+	let nextCandidate = fallbackBase * 100 + 1;
 	for (const insertSection of newInserts) {
 		while (nextCandidate <= safeRangeMax && usedIds.has(nextCandidate)) nextCandidate += 1;
 		const chosenId = nextCandidate <= safeRangeMax ? nextCandidate : allocateFresh();

--- a/test/upload_markdown_edges.spec.ts
+++ b/test/upload_markdown_edges.spec.ts
@@ -462,6 +462,115 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		expect(insertedIds.slice(0, 3)).toEqual([50000, 50001, 50002]);
 	});
 
+	it('allocates fresh global ids (not base+1) when the anchor is already a sub-section id', async () => {
+		// Regression: the EN "Outrage to Overlap" speech was left with 8-digit
+		// sub-section ids (e.g. 63852882). On PATCH, inserting after such an anchor
+		// took the `fallbackBase + 1` branch and walked 63852883, 63852884, … —
+		// ids that sit *below* the global MAX(section_id) counter and are owned by
+		// OTHER speeches, so the INSERT hit "UNIQUE constraint failed:
+		// speech_content.section_id" (surfaced as HTTP 503). loadConflictingSubSectionIds
+		// only pre-blocks [min*100+1, max*100+99] (a far-away ~10-digit window here) and
+		// misses the +1 zone, so anchorId+1 was chosen and collided. The fix forces a
+		// sub-section anchor to allocate fresh global ids.
+		const ops: any[] = [];
+		const requestBody = {
+			filename: 'sub-anchor-insert',
+			markdown: '# X\n## A:\nanchor\n\nbrand new section'
+		};
+		const anchorId = 63852882; // 8 digits → isSubSectionId === true
+		const oldSections = [
+			{ section_id: anchorId, previous_section_id: null, next_section_id: null, section_speaker: 'A', section_content: '<p>anchor</p>' }
+		];
+		const resolver: Resolver = (sql, args) => {
+			if (sql.includes('FROM speech_index WHERE filename = ?')) {
+				return { success: true, results: args[0] === requestBody.filename
+					? [{ filename: requestBody.filename, display_name: 'X', isNested: 0, alternate_filename: null }]
+					: []
+				};
+			}
+			if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
+				return { success: true, results: oldSections };
+			}
+			if (sql.includes('SELECT DISTINCT section_speaker')) {
+				return { success: true, results: [{ section_speaker: 'A' }] };
+			}
+			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
+				return { success: true, results: [{ speaker_route_pathname: 'A' }] };
+			}
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename != ?')) {
+				// loadConflictingSubSectionIds queries the far-away ~10-digit window and
+				// finds nothing — so anchorId+1 (63852883) is NOT pre-blocked.
+				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
+				return { success: true, results: [{ max_id: 70000000 }] };
+			}
+			return { success: true, results: [] };
+		};
+
+		const ctx = {
+			env: {
+				AUDREYT_TRANSCRIPT_TOKEN: 'token-audrey',
+				BESTIAN_TRANSCRIPT_TOKEN: 'token-bestian',
+				SPEECH_CACHE: {
+					get: async () => null,
+					put: async () => {},
+					delete: async () => true,
+					list: async () => ({ objects: [], truncated: false, cursor: '' })
+				},
+				DB: {
+					prepare: (sql: string) => {
+						const run = (args: unknown[]) => ({
+							sql,
+							args,
+							first: async () => resolver(sql, args).results[0] ?? null,
+							all: async () => {
+								const r = resolver(sql, args);
+								return { success: r.success ?? true, results: r.results };
+							},
+							run: async () => ({ success: true, meta: { changes: 1 } })
+						});
+						return {
+							bind: (...args: unknown[]) => run(args),
+							first: async () => run([]).first(),
+							all: async () => run([]).all(),
+							run: async () => run([]).run()
+						};
+					},
+					batch: async (stmts: any[]) => {
+						for (const s of stmts) ops.push(s);
+						return stmts.map(() => ({ meta: { changes: 1 } }));
+					}
+				}
+			},
+			req: {
+				method: 'PATCH',
+				url: 'https://example.com/api/upload_markdown',
+				header: (name: string) => (name === 'Authorization' ? 'Bearer token-audrey' : null),
+				query: () => null,
+				json: async () => requestBody
+			},
+			json: (body: any, status = 200, headers: Record<string, string> = {}) =>
+				new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json', ...headers } }),
+			text: (body: string, status = 200, headers: Record<string, string> = {}) =>
+				new Response(body, { status, headers })
+		} as unknown as Context<ApiEnv>;
+
+		const res = await uploadMarkdown(ctx);
+		expect(res.status).toBe(200);
+
+		const insertedIds = ops
+			.filter((stmt) => typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content'))
+			.map((stmt) => stmt.args[3]);
+		expect(insertedIds.length).toBeGreaterThanOrEqual(1);
+		// Must be fresh global ids (> existing MAX), never the collision-prone anchorId+1.
+		for (const id of insertedIds) {
+			expect(id).toBeGreaterThan(70000000);
+			expect(id).not.toBe(anchorId + 1);
+		}
+		expect(insertedIds[0]).toBe(70000001);
+	});
+
 	it('allocateFresh skips freshIdRef.value when it collides with usedIds', async () => {
 		// 防禦性測試：當 freshIdRef.value（globalMax+1）剛好落在 usedIds 內時，
 		// allocateFresh 的 `while (usedIds.has(freshIdRef.value)) freshIdRef.value += 1`


### PR DESCRIPTION
## Problem

`PATCH /api/upload_markdown` returns **HTTP 503 — `UNIQUE constraint failed: speech_content.section_id`** for any speech that already carries large **sub-section** `section_id`s (8+ digits, e.g. `63852882` left behind by an earlier partial import).

When a new section is inserted after such an anchor, `appendInsertedSections` takes the `fallbackBase + 1` branch and walks `63852883, 63852884, …`. Those candidates sit **below** the global `MAX(section_id)` counter, so they collide with ids owned by **other** speeches on the `speech_content.section_id` PRIMARY KEY.

`loadConflictingSubSectionIds` only pre-blocks `[min*100+1, max*100+99]` — for a sub-section anchor that is a far-away ~10-digit window, so it misses the real collision zone near `base+1`, and the colliding id is chosen.

### Seen in the wild

The EN transcript **`2026-05-28 Outrage to Overlap: Civic AI & 6-Pack of Care`** failed its push-sync on *every* commit (HTTP 503) and never fully synced (74/122 sections live, all with `638526xx` sub-ids). Re-importing via `POST` (which uses fresh sequential ids) restored it; this PR fixes the underlying `PATCH` path so it can't recur.

## Fix

When the insert anchor is already a sub-section id, allocate **guaranteed-unique fresh ids** from the global `MAX(section_id)+1` counter instead of the `base*100+N` / `base+1` locality scheme. Small-id anchors keep the existing locality behaviour, so existing behaviour/tests are unchanged.

```diff
- let nextCandidate = isSubSectionId(fallbackBase) ? fallbackBase + 1 : fallbackBase * 100 + 1;
+ // sub-section anchor → no safe local room below the global counter → fresh ids
+ if (isSubSectionId(fallbackBase)) { /* allocateFresh() for each insert */ return; }
+ let nextCandidate = fallbackBase * 100 + 1;
```

## Tests

- New regression test in `test/upload_markdown_edges.spec.ts` reproducing the 8-digit-anchor insert: asserts inserted ids come from `MAX+1` (fresh) and are never `anchorId + 1`.
- Full suite green: **438 tests / 44 files**. `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)