### PR TITLE
fix(upload_markdown): race-immune atomic section_id allocation + always-fresh inserts

### DIFF
--- a/sql/init-section-id-counter.sql
+++ b/sql/init-section-id-counter.sql
@@ -1,0 +1,19 @@
+-- Atomic allocator for speech_content.section_id (a global INTEGER PRIMARY KEY).
+--
+-- Replaces the old "read MAX(section_id) then compute MAX+1.. in JS" pattern,
+-- which raced across concurrent uploads (two requests read the same MAX, minted
+-- the same ids, and collided on the PK -> HTTP 503). reserveSectionIds() bumps
+-- next_id in a single atomic UPDATE ... RETURNING, so SQLite serialises
+-- concurrent reservations into disjoint id blocks.
+--
+-- The application also creates/seeds this table lazily (CREATE TABLE IF NOT
+-- EXISTS + INSERT OR IGNORE), so applying this migration is optional; it is kept
+-- here for explicit provisioning and documentation. The seed value is irrelevant
+-- because every reservation floors next_id at MAX(section_id)+1 (self-healing).
+CREATE TABLE IF NOT EXISTS section_id_counter (
+    id INTEGER PRIMARY KEY,
+    next_id INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO section_id_counter (id, next_id)
+VALUES (1, (SELECT COALESCE(MAX(section_id), 0) + 1 FROM speech_content));

--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -205,52 +205,53 @@ function assignSpeakersToSections(parsed: ParsedSection[], speakerMarks: Speaker
 }
 
 /**
- * 預先抓出 PATCH 子段落分配 ID 時可能會撞到的「其他 speech 既有 section_id」。
+ * Atomically reserve a contiguous block of `count` fresh section_ids and return
+ * the FIRST id of the block (the block is [start, start + count - 1]).
  *
- * appendInsertedSections 用 `oldId * 100 + N` 規則挑下一個 section_id，原本只
- * 檢查同一篇 speech 的 oldRows——若這個候選值剛好被別篇 speech 的某段落佔走
- * (UNIQUE PK on speech_content.section_id)，INSERT 會在 D1 端炸 503。把
- * 這個區間裡屬於其他 filename 的 section_id 一次撈出來，先丟進 usedIds，
- * appendInsertedSections 內的 `while (usedIds.has(...))` 就會跳過衝突。
+ * speech_content.section_id is a GLOBAL INTEGER PRIMARY KEY. The previous scheme
+ * read MAX(section_id) and then computed MAX+1.. in JS before a separate INSERT,
+ * which (a) raced — two concurrent uploads read the same MAX and minted the same
+ * ids, colliding on the PK and surfacing as HTTP 503 — and (b) tried to place
+ * inserted sections at positional `base*100+N` ids that collided with other
+ * speeches. Both are eliminated here: the reservation is a SINGLE atomic
+ * UPDATE … RETURNING against a dedicated counter row, so SQLite serialises
+ * concurrent reservations into disjoint blocks, and the counter is always bumped
+ * to at least MAX(section_id)+1 (self-healing) so every reserved id is strictly
+ * greater than any existing row — collision-free by construction.
  *
- * 只覆蓋第一層子段落 [oldId*100+1, oldId*100+99]——足以解決實務上撞到的
- * cross-speech 重號。第二層以上 (sub-sub) 的衝突極罕見，需要時再延伸。
+ * Reserved ids are pure identity, never positional; display order is carried by
+ * the previous/next link chain (see sectionUtils), so gaps are harmless.
  */
-async function loadConflictingSubSectionIds(
-	c: Context<ApiEnv>,
-	currentFilename: string,
-	oldSections: ExistingSection[]
-): Promise<Set<number>> {
-	// 呼叫端保證 oldSections.length > 0（PATCH 內 length === 0 走另一條分支）。
-	const ids = oldSections.map((section) => section.section_id);
-	const lo = Math.min(...ids) * 100 + 1;
-	const hi = Math.max(...ids) * 100 + 99;
-
-	const result = await withRetry(() =>
-		c.env.DB.prepare(
-			'SELECT section_id FROM speech_content WHERE filename != ? AND section_id BETWEEN ? AND ?'
-		)
-			.bind(currentFilename, lo, hi)
-			.all<{ section_id: number }>()
+async function reserveSectionIds(c: Context<ApiEnv>, count: number): Promise<number> {
+	const n = Math.max(1, Math.floor(count));
+	// Idempotent: create the counter table + seed row if missing. The seed value
+	// (0) is irrelevant because the reservation below floors next_id at MAX+1.
+	await withRetry(() =>
+		c.env.DB.batch([
+			c.env.DB.prepare(
+				'CREATE TABLE IF NOT EXISTS section_id_counter (id INTEGER PRIMARY KEY, next_id INTEGER NOT NULL)'
+			),
+			c.env.DB.prepare('INSERT OR IGNORE INTO section_id_counter (id, next_id) VALUES (1, 0)')
+		])
 	);
-	const blocked = new Set<number>();
-	for (const row of result.results ?? []) {
-		blocked.add(Number(row.section_id));
+	// The atomic reservation: one statement, serialised by SQLite's write lock.
+	// next_id := max(current counter, MAX(section_id)+1) + n ; reserved block is
+	// the n ids immediately below the returned next_id.
+	const row = await withRetry(() =>
+		c.env.DB.prepare(
+			`UPDATE section_id_counter
+			 SET next_id = MAX(next_id, (SELECT COALESCE(MAX(section_id), 0) + 1 FROM speech_content)) + ?
+			 WHERE id = 1
+			 RETURNING next_id`
+		)
+			.bind(n)
+			.first<{ next_id: number | string }>()
+	);
+	const newNext = row != null ? Number(row.next_id) : NaN;
+	if (!Number.isFinite(newNext)) {
+		throw new Error('reserveSectionIds: counter update returned no row');
 	}
-	return blocked;
-}
-
-async function findMaxSectionId(c: Context<ApiEnv>): Promise<number> {
-	// SQLite optimises MAX on INTEGER PRIMARY KEY to O(1) — no WHERE clause so
-	// the B-tree tail lookup is used instead of a full table scan.
-	const result = await c.env.DB.prepare(
-		'SELECT MAX(section_id) AS max_id FROM speech_content'
-	).first<{ max_id: number | null }>();
-	const maxId = result?.max_id;
-	// D1 可能回傳 string，強制轉數值
-	const num = maxId != null ? Number(maxId) : 0;
-	const next = Number.isNaN(num) ? 0 : num + 1;
-	return next;
+	return newNext - n;
 }
 
 /** Markdown 轉 HTML 並移除 <script> */
@@ -321,11 +322,6 @@ function sectionMatchKey(section: { markdown: string; speaker: string | null }) 
 		return `${section.speaker ?? ''}\u0000__embedded_${mediaTag}__`;
 	}
 	return `${section.speaker ?? ''}\u0000${normalizeSectionComparableContent(section.markdown)}`;
-}
-
-/** 是否為「子段落 ID」（插入時用 base*100+1 等規則產生的長數字） */
-function isSubSectionId(sectionId: number) {
-	return String(Math.abs(sectionId)).length > 7;
 }
 
 /** 依 previous/next 鏈結將 DB 取出的段落排成正確順序；找不到頭則改依 section_id 排序 */
@@ -404,69 +400,21 @@ function buildLcsPairs(oldSections: SectionPayload[], newSections: SectionPayloa
 }
 
 /**
- * PATCH 時為「新插入的段落」分配 section_id。
+ * PATCH 用：以 LCS 對齊舊/新段落，能對上的沿用舊 section_id（URL 穩定），多出來
+ * 的新段落用 `allocateFresh()` 取得全域唯一的新 ID。
  *
- * 優先用 `base*100+N` 規則（讓子段落 ID 在 parent 附近，URL 比較有 locality）；
- * 但如果該 sub-section slot `[base*100+1, base*100+99]` 撞滿（被 oldRows 自己用掉、
- * 或被 loadConflictingSubSectionIds 預先標記為別篇 speech 佔走），nextCandidate 會
- * `+= 1` 一路 overflow 出 `safeRangeMax`（= max(oldId)*100+99，也就是 query 覆蓋的
- * 上界）；那邊一旦也被別篇 speech 佔走 → INSERT UNIQUE PK fail。
- *
- * Overflow 時改從 `freshIdRef.value`（globalMaxSectionId+1 起算）拿一個保證沒人用的 ID，
- * 因為 fresh 區段一定 > 任何 existing section_id，跨 speech 不會撞。
+ * allocateFresh() draws sequentially from a block pre-reserved via
+ * reserveSectionIds (globalMax+1..), so every inserted id is strictly greater
+ * than every existing section_id and than every other id minted this request —
+ * cross-speech / intra-request UNIQUE-PK collisions are impossible by
+ * construction. There is no positional `base*100+N` scheme any more: section_id
+ * is pure identity and display order comes from the previous/next link chain
+ * (withSectionLinks + sectionUtils), so non-local inserted ids are fine.
  */
-function appendInsertedSections(
-	output: PatchAssignedSection[],
-	newInserts: SectionPayload[],
-	baseIdHint: number | null,
-	usedIds: Set<number>,
-	safeRangeMax: number,
-	freshIdRef: { value: number }
-) {
-	if (newInserts.length > 99) throw new Error('Too many inserted sections in a single gap (max 99)');
-
-	const fallbackBase = output.length > 0 ? output[output.length - 1].section_id : baseIdHint ?? 0;
-
-	const allocateFresh = (): number => {
-		while (usedIds.has(freshIdRef.value)) freshIdRef.value += 1;
-		const id = freshIdRef.value;
-		freshIdRef.value += 1;
-		return id;
-	};
-
-	// When the anchor is already a "large" sub-section id, the base*100+N / base+1
-	// locality scheme has no safe room: those candidates fall *below* the global
-	// MAX(section_id) counter and walk straight into ids owned by OTHER speeches,
-	// hitting "UNIQUE constraint failed: speech_content.section_id" on INSERT (503).
-	// loadConflictingSubSectionIds only pre-blocks [min*100+1, max*100+99], which for
-	// a sub-section anchor is a far-away ~10-digit window that misses the real
-	// collision zone near base+1. For those anchors, allocate guaranteed-unique
-	// fresh ids (globalMax+1…) instead; small-id anchors keep the locality scheme.
-	if (isSubSectionId(fallbackBase)) {
-		for (const insertSection of newInserts) {
-			const chosenId = allocateFresh();
-			usedIds.add(chosenId);
-			output.push({ ...insertSection, section_id: chosenId });
-		}
-		return;
-	}
-
-	let nextCandidate = fallbackBase * 100 + 1;
-	for (const insertSection of newInserts) {
-		while (nextCandidate <= safeRangeMax && usedIds.has(nextCandidate)) nextCandidate += 1;
-		const chosenId = nextCandidate <= safeRangeMax ? nextCandidate : allocateFresh();
-		if (chosenId === nextCandidate) nextCandidate += 1;
-		usedIds.add(chosenId);
-		output.push({ ...insertSection, section_id: chosenId });
-	}
-}
-
-/** PATCH 用：以 LCS 對齊舊/新段落，能對上的沿用舊 section_id，多出來的新段落分配新 ID */
 function assignPatchedSections(
 	oldRows: ExistingSection[],
 	newSections: SectionPayload[],
-	extraBlockedIds: ReadonlySet<number>,
-	freshIdStart: number
+	allocateFresh: () => number
 ): PatchAssignedSection[] {
 	const oldSections: Array<SectionPayload & { section_id: number }> = oldRows.map((row) => ({
 		section_id: row.section_id,
@@ -475,13 +423,12 @@ function assignPatchedSections(
 		section_content: row.section_content
 	}));
 	const output: PatchAssignedSection[] = [];
-	const usedIds = new Set<number>(oldRows.map((row) => row.section_id));
-	for (const blocked of extraBlockedIds) usedIds.add(blocked);
-	const oldIds = oldRows.map((row) => row.section_id);
-	const safeRangeMax = oldIds.length > 0 ? Math.max(...oldIds) * 100 + 99 : 0;
-	const freshIdRef = { value: freshIdStart };
 	let oldCursor = 0;
 	let newCursor = 0;
+
+	const emit = (section: SectionPayload, sectionId: number) => {
+		output.push({ ...section, section_id: sectionId });
+	};
 
 	// Special case: 改第一段（新第一段是陌生內容）時，強制沿用舊第一段 section_id
 	if (
@@ -489,7 +436,7 @@ function assignPatchedSections(
 		newSections.length > 0 &&
 		sectionMatchKey(oldSections[0]) !== sectionMatchKey(newSections[0])
 	) {
-		output.push({ ...newSections[0], section_id: oldSections[0].section_id });
+		emit(newSections[0], oldSections[0].section_id);
 		oldCursor = 1;
 		newCursor = 1;
 	}
@@ -503,21 +450,11 @@ function assignPatchedSections(
 		const newGap = newSections.slice(newCursor, newMatchIdx);
 		const pairedCount = Math.min(oldGap.length, newGap.length);
 
-		for (let k = 0; k < pairedCount; k += 1) {
-			output.push({ ...newGap[k], section_id: oldGap[k].section_id });
-		}
+		// Reuse old ids for paired sections in the gap; fresh ids for the rest.
+		for (let k = 0; k < pairedCount; k += 1) emit(newGap[k], oldGap[k].section_id);
+		for (let k = pairedCount; k < newGap.length; k += 1) emit(newGap[k], allocateFresh());
 
-		if (newGap.length > oldGap.length) {
-			const baseIdHint =
-				pairedCount > 0
-					? oldGap[pairedCount - 1].section_id
-					: output.length > 0
-						? output[output.length - 1].section_id
-						: oldSections[0]?.section_id ?? null;
-			appendInsertedSections(output, newGap.slice(pairedCount), baseIdHint, usedIds, safeRangeMax, freshIdRef);
-		}
-
-		output.push({ ...newSections[newMatchIdx], section_id: oldSections[oldMatchIdx].section_id });
+		emit(newSections[newMatchIdx], oldSections[oldMatchIdx].section_id);
 		oldCursor = oldMatchIdx + 1;
 		newCursor = newMatchIdx + 1;
 	}
@@ -526,19 +463,8 @@ function assignPatchedSections(
 	const newTail = newSections.slice(newCursor);
 	const tailPairCount = Math.min(oldTail.length, newTail.length);
 
-	for (let k = 0; k < tailPairCount; k += 1) {
-		output.push({ ...newTail[k], section_id: oldTail[k].section_id });
-	}
-
-	if (newTail.length > oldTail.length) {
-		const baseIdHint =
-			tailPairCount > 0
-				? oldTail[tailPairCount - 1].section_id
-				: output.length > 0
-					? output[output.length - 1].section_id
-					: oldSections[0]?.section_id ?? null;
-		appendInsertedSections(output, newTail.slice(tailPairCount), baseIdHint, usedIds, safeRangeMax, freshIdRef);
-	}
+	for (let k = 0; k < tailPairCount; k += 1) emit(newTail[k], oldTail[k].section_id);
+	for (let k = tailPairCount; k < newTail.length; k += 1) emit(newTail[k], allocateFresh());
 
 	return output;
 }
@@ -863,7 +789,8 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 
 			const { speakers, sectionPayloads } = await parseIncomingMarkdown(markdown);
 			const speakerRoutePathnames = getUniqueSpeakerRoutePathnames(speakers);
-			const baseSectionId = await withRetry(() => findMaxSectionId(c));
+			// Atomically reserve a contiguous, collision-free block of ids.
+			const baseSectionId = await reserveSectionIds(c, sectionPayloads.length);
 
 			// 為每個段落分配連續的 section_id 與 prev/next 鏈結
 			const normalized: NormalizedSection[] = sectionPayloads.map((section, idx) => {
@@ -1062,26 +989,18 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 			const { speakers, sectionPayloads } = await parseIncomingMarkdown(markdown);
 			const newSpeakerRoutePathnames = getUniqueSpeakerRoutePathnames(speakers);
 
-			let assignedPatched: PatchAssignedSection[];
-			if (oldSections.length === 0) {
-				// 安全補強：若舊資料沒有任何段落，改用 POST 式連號分配，避免 ID 無基準導致失敗
-				const baseSectionId = await withRetry(() => findMaxSectionId(c));
-				assignedPatched = sectionPayloads.map((section, idx) => ({
-					...section,
-					section_id: baseSectionId + idx
-				}));
-			} else {
-				const blockedSubIds = await loadConflictingSubSectionIds(c, filename, oldSections);
-				// freshIdStart 用 globalMaxSectionId+1 起算；當 sub-section slot 撞滿、
-				// nextCandidate overflow 出 safeRangeMax 時 appendInsertedSections 會改用這裡的 ID。
-				const freshIdStart = await withRetry(() => findMaxSectionId(c));
-				try {
-					assignedPatched = assignPatchedSections(oldSections, sectionPayloads, blockedSubIds, freshIdStart);
-				} catch (err) {
-					const message = err instanceof Error ? err.message : 'Failed to assign section ids for PATCH';
-					return c.json({ success: false, message, filename }, 409, corsHeadersWithMethods);
-				}
-			}
+			// Reserve a contiguous, collision-free block of fresh ids up front.
+			// sectionPayloads.length is an upper bound on how many we can need
+			// (matched sections reuse their old ids); any unused reserved ids are
+			// harmless gaps. The reservation is atomic, so concurrent uploads never
+			// collide on the global section_id PK.
+			const reservedStart = await reserveSectionIds(c, sectionPayloads.length);
+			let nextFreshId = reservedStart;
+			const allocateFresh = () => nextFreshId++;
+			const assignedPatched: PatchAssignedSection[] =
+				oldSections.length === 0
+					? sectionPayloads.map((section) => ({ ...section, section_id: allocateFresh() }))
+					: assignPatchedSections(oldSections, sectionPayloads, allocateFresh);
 
 			const normalized = withSectionLinks(assignedPatched);
 			// 既有段落 ID（DB 原本有的）；finalSectionIds = PATCH 後要保留的 ID（供刪除用）

--- a/src/search/runtime.ts
+++ b/src/search/runtime.ts
@@ -11,6 +11,7 @@ import {
 	type SearchOverlayManifest
 } from './indexFormat';
 import { docsFromSections, type ApiSection } from './docBuilder';
+import { normalizeSections } from '../utils/sectionUtils';
 
 const SEARCH_MANIFEST_CACHE_CONTROL = 'public, max-age=60, s-maxage=60';
 const SEARCH_UPDATE_CACHE_CONTROL = 'public, max-age=3600, s-maxage=86400';
@@ -119,6 +120,8 @@ export async function buildSearchDocsForSpeech(
 			sc.filename,
 			sc.nest_filename,
 			sc.section_id,
+			sc.previous_section_id,
+			sc.next_section_id,
 			sc.section_content,
 			si.display_name,
 			sp.name
@@ -127,16 +130,24 @@ export async function buildSearchDocsForSpeech(
 		LEFT JOIN speakers sp ON sc.section_speaker = sp.route_pathname
 		WHERE sc.filename = ?
 		ORDER BY sc.section_id ASC`
-	).bind(filename).all<ApiSection>();
+	).bind(filename).all<ApiSection & { previous_section_id: number | null; next_section_id: number | null }>();
 
-	const sections = (rows.results ?? []).map((row) => ({
-		filename: row.filename,
-		nest_filename: row.nest_filename ?? null,
-		section_id: Number(row.section_id),
-		section_content: row.section_content ?? '',
-		display_name: row.display_name ?? filename,
-		name: row.name ?? null
-	}));
+	// Order by the previous/next link chain (true display order), NOT raw section_id.
+	// Inserted sections get fresh ids far above their neighbours, so a section_id ASC
+	// sort would scramble the excerpt; normalizeSections returns rows untouched when
+	// already in chain order, otherwise re-stitches them by the link chain.
+	const sections = normalizeSections(
+		(rows.results ?? []).map((row) => ({
+			filename: row.filename,
+			nest_filename: row.nest_filename ?? null,
+			section_id: Number(row.section_id),
+			previous_section_id: row.previous_section_id != null ? Number(row.previous_section_id) : null,
+			next_section_id: row.next_section_id != null ? Number(row.next_section_id) : null,
+			section_content: row.section_content ?? '',
+			display_name: row.display_name ?? filename,
+			name: row.name ?? null
+		}))
+	);
 
 	if (sections.length === 0) return [];
 	return docsFromSections(sections, `/${encodeURIComponent(filename)}`, filename);

--- a/test/upload_markdown.spec.ts
+++ b/test/upload_markdown.spec.ts
@@ -72,8 +72,9 @@ function createUploadEnv(options?: {
 		if (sql.includes('FROM speech_index WHERE filename = ?')) {
 			return { success: true, results: speechIndexRows.filter((row) => row.filename === args[0]) };
 		}
-		if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
-			return { success: true, results: [{ max_id: oldSections[oldSections.length - 1]?.section_id ?? 0 }] };
+		if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+			const start = (oldSections[oldSections.length - 1]?.section_id ?? 0) + 1;
+			return { success: true, results: [{ next_id: start + Number(args[0] || 1) }] };
 		}
 		if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
 			return { success: true, results: args[0] === 'demo-speech' ? oldSections : [] };
@@ -137,6 +138,7 @@ function createUploadEnv(options?: {
 	}
 
 	function applyStatement(stmt: PreparedStatement) {
+		if (typeof stmt.sql !== 'string') return;
 		operations.push(stmt);
 	}
 
@@ -240,7 +242,7 @@ describe('upload_markdown PATCH', () => {
 			.map((stmt) => stmt.args[3]);
 
 		expect(updateSectionIds).toEqual([100, 101]);
-		expect(insertedSectionIds).toEqual([10001]);
+		expect(insertedSectionIds).toEqual([102]);
 		expect(env.__deletedKeys).toEqual(
 			expect.arrayContaining([
 				`${CACHE_KEY_VERSION}/example.com/speeches`,

--- a/test/upload_markdown_coverage_final.spec.ts
+++ b/test/upload_markdown_coverage_final.spec.ts
@@ -30,7 +30,14 @@ function env(resolver: Resolver) {
 				const run = (args: unknown[]) => ({
 					sql,
 					args,
-					first: async () => resolver(sql, args).results[0] ?? null,
+					first: async () => {
+						const row = resolver(sql, args).results[0];
+						if (row != null) return row;
+						if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+							return { next_id: 1 + Number(args[0] || 1) };
+						}
+						return null;
+					},
 					all: async () => {
 						const r = resolver(sql, args);
 						return { success: r.success ?? true, results: r.results };
@@ -48,7 +55,9 @@ function env(resolver: Resolver) {
 				};
 			},
 			batch: async (stmts: any[]) => {
-				for (const s of stmts) operations.push({ sql: s.sql, args: s.args });
+				for (const s of stmts) {
+					if (typeof s.sql === 'string') operations.push({ sql: s.sql, args: s.args });
+				}
 				return stmts.map(() => ({ meta: { changes: 1 } }));
 			}
 		}
@@ -228,7 +237,9 @@ describe('PATCH alternate_filename explicit null', () => {
 			if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
 				return { success: true, results: [] };
 			}
-			if (sql.includes('SELECT MAX(section_id)')) return { success: true, results: [{ max_id: 1000 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return { success: true, results: [{ next_id: 1001 + Number(args[0] || 1) }] };
+			}
 			return { success: true, results: [] };
 		});
 		const { res } = await req('/api/upload_markdown', e, {
@@ -244,10 +255,11 @@ describe('PATCH alternate_filename explicit null', () => {
 	});
 });
 
-describe('PATCH >99 inserts triggers 409', () => {
-	it('returns 409 when one gap contains more than 99 new sections', async () => {
-		// Old: single section X. New: X + 100 new sections — appendInsertedSections throws.
-		// uploadMarkdown catches and returns 409.
+describe('PATCH >99 inserts uses reserved fresh ids', () => {
+	it('succeeds when one gap contains more than 99 new sections', async () => {
+		// Old: single section X. New: X + 100 new sections. The removed 99-id
+		// positional gap cap no longer applies; inserted sections come from the
+		// fresh reserved id block.
 		const oldSections = [
 			{ section_id: 500, previous_section_id: null, next_section_id: null, section_speaker: 'A', section_content: '<p>anchor-X</p>' }
 		];
@@ -264,13 +276,16 @@ describe('PATCH >99 inserts triggers 409', () => {
 			if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
 				return { success: true, results: oldSections };
 			}
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return { success: true, results: [{ next_id: 501 + Number(args[0] || 1) }] };
+			}
 			if (sql.includes('FROM speech_speakers WHERE speech_filename = ?')) {
 				return { success: true, results: [] };
 			}
 			return { success: true, results: [] };
 		});
-		// Anchor-X match preserved, with 100 inserts before it.
-		const newSections = Array.from({ length: 100 }, (_, i) => `## A:\ninserted-${i}`).join('\n\n') + '\n\n## A:\nanchor-X';
+		// Anchor-X match preserved, with 100 inserts after it.
+		const newSections = '## A:\nanchor-X\n\n' + Array.from({ length: 100 }, (_, i) => `## A:\ninserted-${i}`).join('\n\n');
 		const { res } = await req('/api/upload_markdown', e, {
 			method: 'PATCH',
 			headers: { Authorization: 'Bearer token-audrey', 'Content-Type': 'application/json' },
@@ -279,10 +294,22 @@ describe('PATCH >99 inserts triggers 409', () => {
 				markdown: `# Too Many\n${newSections}`
 			})
 		});
-		expect(res.status).toBe(409);
+		expect(res.status).toBe(200);
 		const body = (await res.json()) as any;
-		expect(body.success).toBe(false);
-		expect(body.message).toContain('Too many inserted sections');
+		expect(body).toMatchObject({
+			success: true,
+			filename: 'too-many',
+			sectionsCount: 101,
+			insertedCount: 100,
+			updatedCount: 1,
+			deletedCount: 0
+		});
+		const insertedIds = e.__operations
+			.filter((stmt) => typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content'))
+			.map((stmt) => stmt.args[3]);
+		expect(insertedIds).toHaveLength(100);
+		expect(new Set(insertedIds).size).toBe(100);
+		expect(insertedIds).toEqual(Array.from({ length: 100 }, (_, i) => 501 + i));
 	});
 });
 
@@ -299,11 +326,13 @@ describe('decodeURIComponent catch for speaker name', () => {
 		// for the decode step, still contains an unpaired `%`. Since that's impossible
 		// through normalizeSpeakerName, we smoke-test the happy path here to keep
 		// things executing; the catch is defensive and guarded.
-		const e = env((sql) => {
+		const e = env((sql, args) => {
 			if (sql.includes('SELECT filename FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: [] };
 			}
-			if (sql.includes('SELECT MAX(section_id)')) return { success: true, results: [{ max_id: 10 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return { success: true, results: [{ next_id: 11 + Number(args[0] || 1) }] };
+			}
 			return { success: true, results: [] };
 		});
 		const { res } = await req('/api/upload_markdown', e, {

--- a/test/upload_markdown_direct.spec.ts
+++ b/test/upload_markdown_direct.spec.ts
@@ -21,7 +21,14 @@ function makeContext(overrides: Partial<{
 			const run = (args: unknown[]) => ({
 				sql,
 				args,
-				first: async () => resolver(sql, args).results[0] ?? null,
+				first: async () => {
+					const row = resolver(sql, args).results[0];
+					if (row != null) return row;
+					if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+						return { next_id: 1 + Number(args[0] || 1) };
+					}
+					return null;
+				},
 				all: async () => {
 					const r = resolver(sql, args);
 					return { success: r.success ?? true, results: r.results };
@@ -36,7 +43,9 @@ function makeContext(overrides: Partial<{
 			};
 		},
 		batch: async (stmts: any[]) => {
-			for (const stmt of stmts) batchStatements.push({ sql: stmt.sql, args: stmt.args });
+			for (const stmt of stmts) {
+				if (typeof stmt.sql === 'string') batchStatements.push({ sql: stmt.sql, args: stmt.args });
+			}
 			return stmts.map((_, i) => ({ meta: { changes: changes[i] ?? 1 } }));
 		}
 	};

--- a/test/upload_markdown_edges.spec.ts
+++ b/test/upload_markdown_edges.spec.ts
@@ -9,6 +9,10 @@ const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
 
 type Resolver = (sql: string, args: unknown[]) => { success?: boolean; results: any[] };
 
+function reservedCounterResult(maxSectionId: number, args: unknown[]) {
+	return { success: true, results: [{ next_id: maxSectionId + 1 + Number(args[0] || 1) }] };
+}
+
 function makeUploadEnv(resolver: Resolver, options: { batchChanges?: number[]; failSearchSync?: boolean } = {}) {
 	const deletedKeys: string[] = [];
 	const putObjects = new Map<string, string>();
@@ -43,7 +47,17 @@ function makeUploadEnv(resolver: Resolver, options: { batchChanges?: number[]; f
 				const run = (args: unknown[]) => ({
 					sql,
 					args,
-					first: async () => resolver(sql, args).results[0] ?? null,
+					first: async () => {
+						const fromResolver = resolver(sql, args).results[0];
+						if (fromResolver != null) return fromResolver;
+						// Default reservation: reserveSectionIds() issues
+						// `UPDATE section_id_counter ... RETURNING next_id`; return a
+						// block starting at 1 unless the test's resolver overrides it.
+						if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+							return { next_id: 1 + (Number((args as unknown[])[0]) || 1) };
+						}
+						return null;
+					},
 					all: async () => {
 						const r = resolver(sql, args);
 						return { success: r.success ?? true, results: r.results };
@@ -61,7 +75,9 @@ function makeUploadEnv(resolver: Resolver, options: { batchChanges?: number[]; f
 				};
 			},
 			batch: async (stmts: any[]) => {
-				for (const stmt of stmts) operations.push({ sql: stmt.sql, args: stmt.args });
+				for (const stmt of stmts) {
+					if (typeof stmt.sql === 'string') operations.push({ sql: stmt.sql, args: stmt.args });
+				}
 				return stmts.map((_, i) => ({ meta: { changes: changes[i] ?? 1 } }));
 			}
 		}
@@ -75,13 +91,121 @@ async function request(path: string, env: ReturnType<typeof makeUploadEnv>, init
 	return { res };
 }
 
-describe('parseMarkdownSections edge branches', () => {
-	it('quote-only section gets speaker=null', async () => {
-		const env = makeUploadEnv((sql) => {
+describe('reserveSectionIds atomic reservation', () => {
+	it('hands out disjoint id blocks across sequential POSTs', async () => {
+		let counter = 100;
+		let tableMax = 99;
+		const idsByFilename = new Map<string, number[]>();
+		const operations: Array<{ sql: string; args: unknown[] }> = [];
+
+		const query = (sql: string, args: unknown[]) => {
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				const n = Number(args[0] || 1);
+				counter = Math.max(counter, tableMax + 1) + n;
+				return { success: true, results: [{ next_id: counter }] };
+			}
 			if (sql.includes('SELECT filename FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: [] };
 			}
-			if (sql.includes('SELECT MAX(section_id)')) return { success: true, results: [{ max_id: 100 }] };
+			if (sql.includes('FROM speech_index WHERE filename = ?')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
+				return { success: true, results: (idsByFilename.get(String(args[0])) ?? []).map((section_id) => ({ section_id })) };
+			}
+			if (sql.includes('FROM speech_content sc') && sql.includes('LEFT JOIN speech_index si ON sc.filename = si.filename')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT COUNT(*) AS count')) {
+				return { success: true, results: [{ count: 0 }] };
+			}
+			if (sql.includes('FROM speech_speakers WHERE speech_filename = ?')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('FROM speech_redirects WHERE old_filename = ?')) {
+				return { success: true, results: [] };
+			}
+			return { success: true, results: [] };
+		};
+
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'token-audrey',
+			BESTIAN_TRANSCRIPT_TOKEN: 'token-bestian',
+			ASSETS: { fetch: () => new Response('NF', { status: 404 }) },
+			SPEECH_CACHE: {
+				delete: async () => true,
+				get: async () => null,
+				put: async () => {},
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: (sql: string) => {
+					const statement = (args: unknown[] = []): any => ({
+						sql,
+						args,
+						bind: (...bound: unknown[]) => statement(bound),
+						first: async () => query(sql, args).results[0] ?? null,
+						all: async () => {
+							const result = query(sql, args);
+							return { success: result.success ?? true, results: result.results };
+						},
+						run: async () => ({ success: true, meta: { changes: 1 } })
+					});
+					return statement();
+				},
+				batch: async (stmts: any[]) => {
+					for (const stmt of stmts) {
+						operations.push({ sql: stmt.sql, args: stmt.args ?? [] });
+						if (typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content')) {
+							for (let i = 0; i < stmt.args.length; i += 8) {
+								const filename = String(stmt.args[i]);
+								const sectionId = Number(stmt.args[i + 3]);
+								const ids = idsByFilename.get(filename) ?? [];
+								ids.push(sectionId);
+								idsByFilename.set(filename, ids);
+								tableMax = Math.max(tableMax, sectionId);
+							}
+						}
+					}
+					return stmts.map(() => ({ meta: { changes: 1 } }));
+				}
+			},
+			__operations: operations
+		};
+
+		const post = async (filename: string, markdown: string) => {
+			const req = new IncomingRequest('https://example.com/api/upload_markdown', {
+				method: 'POST',
+				headers: { Authorization: 'Bearer token-audrey', 'Content-Type': 'application/json' },
+				body: JSON.stringify({ filename, markdown })
+			});
+			const ctx = createExecutionContext();
+			return worker.fetch(req, env as any, ctx);
+		};
+
+		const first = await post('race-one', '# Race One\nA\n\nB');
+		const second = await post('race-two', '# Race Two\nA\n\nB\n\nC');
+
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+		const firstIds = idsByFilename.get('race-one') ?? [];
+		const secondIds = idsByFilename.get('race-two') ?? [];
+		expect(firstIds).toEqual([100, 101]);
+		expect(secondIds).toEqual([102, 103, 104]);
+		expect(Math.min(...secondIds)).toBeGreaterThan(Math.max(...firstIds));
+		expect(new Set([...firstIds, ...secondIds]).size).toBe(firstIds.length + secondIds.length);
+	});
+});
+
+describe('parseMarkdownSections edge branches', () => {
+	it('quote-only section gets speaker=null', async () => {
+		const env = makeUploadEnv((sql, args) => {
+			if (sql.includes('SELECT filename FROM speech_index WHERE filename = ?')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(100, args);
+			}
 			return { success: true, results: [] };
 		});
 		const { res } = await request('/api/upload_markdown', env, {
@@ -102,11 +226,13 @@ describe('parseMarkdownSections edge branches', () => {
 	});
 
 	it('drops empty speaker names (heading `## : ` with no name)', async () => {
-		const env = makeUploadEnv((sql) => {
+		const env = makeUploadEnv((sql, args) => {
 			if (sql.includes('SELECT filename FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: [] };
 			}
-			if (sql.includes('SELECT MAX(section_id)')) return { success: true, results: [{ max_id: 200 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(200, args);
+			}
 			return { success: true, results: [] };
 		});
 		const { res } = await request('/api/upload_markdown', env, {
@@ -175,7 +301,7 @@ describe('orderSectionsByLinks and assignPatchedSections branches', () => {
 describe('invalidateSpeakerCaches empty-route skip branch', () => {
 	it('skips cache invalidation entries for empty/null speaker routes', async () => {
 		// Construct a DELETE scenario where speech_speakers contains a row with null route_pathname.
-		const env = makeUploadEnv((sql) => {
+		const env = makeUploadEnv((sql, args) => {
 			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
 				return {
 					success: true,
@@ -201,11 +327,13 @@ describe('invalidateSpeakerCaches empty-route skip branch', () => {
 
 describe('syncSearchArtifacts error logging', () => {
 	it('logs but does not fail upsert when the search sync rejects', async () => {
-		const env = makeUploadEnv((sql) => {
+		const env = makeUploadEnv((sql, args) => {
 			if (sql.includes('SELECT filename FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: [] };
 			}
-			if (sql.includes('SELECT MAX(section_id)')) return { success: true, results: [{ max_id: 300 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(300, args);
+			}
 			return { success: true, results: [] };
 		}, { failSearchSync: true });
 
@@ -268,6 +396,10 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
 				return { success: true, results: [{ speaker_route_pathname: 'A' }] };
 			}
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				const maxSectionId = Math.max(0, ...oldSections.map((section) => Number(section.section_id) || 0));
+				return reservedCounterResult(maxSectionId, args);
+			}
 			return { success: true, results: [] };
 		};
 
@@ -286,7 +418,14 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						const run = (args: unknown[]) => ({
 							sql,
 							args,
-							first: async () => resolver(sql, args).results[0] ?? null,
+							first: async () => {
+								const row = resolver(sql, args).results[0];
+								if (row != null) return row;
+								if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+									return { next_id: 1 + Number(args[0] || 1) };
+								}
+								return null;
+							},
 							all: async () => {
 								const r = resolver(sql, args);
 								return { success: r.success ?? true, results: r.results };
@@ -301,7 +440,9 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						};
 					},
 					batch: async (stmts: any[]) => {
-						for (const s of stmts) ops.push(s);
+						for (const s of stmts) {
+							if (typeof s.sql === 'string') ops.push(s);
+						}
 						return stmts.map(() => ({ meta: { changes: 1 } }));
 					}
 				}
@@ -324,7 +465,7 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 
 	it('threads new sections into a short old list (tail-insertion with no LCS matches)', async () => {
 		// Old list has 1 section with content that doesn't match new sections — LCS pairs is empty.
-		// appendInsertedSections runs via the tail path (line 419) with baseIdHint derived from output.
+		// The first changed section reuses the old id and the remaining tail uses reserved fresh ids.
 		const { ctx } = makeCtx([
 			{ section_id: 500, previous_section_id: null, next_section_id: null, section_speaker: 'A', section_content: '<p>totally-different-old-content</p>' }
 		]);
@@ -332,7 +473,7 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		expect(res.status).toBe(200);
 	});
 
-	it('skips over an already-used generated section id inside an insertion gap', async () => {
+	it('allocates a reserved fresh id inside an insertion gap', async () => {
 		const { ctx, ops } = makeCtx(
 			[
 				{ section_id: 1, previous_section_id: null, next_section_id: 101, section_speaker: 'A', section_content: '<p>anchor one</p>' },
@@ -349,18 +490,12 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		const insertedIds = ops
 			.filter((stmt) => typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content'))
 			.map((stmt) => stmt.args[3]);
-		expect(insertedIds).toContain(102);
+		expect(insertedIds).toEqual([102]);
 	});
 
-	it('falls back to globalMax+1 fresh IDs when the sub-section slot is fully blocked (overflow guard)', async () => {
-		// Old single section id 1 → sub-section slot is [101, 199] (99 ids).
-		// Mock the cross-filename query to return ALL 99 ids as taken, simulating the
-		// production case where another speech's contiguous range exhausts the entire
-		// [base*100+1, base*100+99] window. Without the fresh-ID fallback, nextCandidate
-		// would overflow past safeRangeMax (199) into the unguarded [200, …] range
-		// — and would hit "UNIQUE constraint failed: speech_content.section_id" if
-		// another speech happens to own those ids too.
-		// findMaxSectionId is mocked to 50000 so the fresh allocator should start at 50000.
+	it('allocates sequential reserved fresh IDs for multiple inserted sections', async () => {
+		// The old positional sub-section window is gone. Inserts are allocated from
+		// the reserved global block, starting at max(section_id)+1.
 		const ops: any[] = [];
 		const requestBody = {
 			filename: 'overflow-fresh',
@@ -369,7 +504,6 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		const oldSections = [
 			{ section_id: 1, previous_section_id: null, next_section_id: null, section_speaker: 'A', section_content: '<p>anchor</p>' }
 		];
-		const fullyBlockedRange = Array.from({ length: 99 }, (_, i) => ({ section_id: 101 + i }));
 		const resolver: Resolver = (sql, args) => {
 			if (sql.includes('FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: args[0] === requestBody.filename
@@ -389,11 +523,8 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
 				return { success: true, results: [{ speaker_route_pathname: 'A' }] };
 			}
-			if (sql.includes('SELECT section_id FROM speech_content WHERE filename != ?')) {
-				return { success: true, results: fullyBlockedRange };
-			}
-			if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
-				return { success: true, results: [{ max_id: 49999 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(49999, args);
 			}
 			return { success: true, results: [] };
 		};
@@ -413,7 +544,14 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						const run = (args: unknown[]) => ({
 							sql,
 							args,
-							first: async () => resolver(sql, args).results[0] ?? null,
+							first: async () => {
+								const row = resolver(sql, args).results[0];
+								if (row != null) return row;
+								if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+									return { next_id: 1 + Number(args[0] || 1) };
+								}
+								return null;
+							},
 							all: async () => {
 								const r = resolver(sql, args);
 								return { success: r.success ?? true, results: r.results };
@@ -428,7 +566,9 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						};
 					},
 					batch: async (stmts: any[]) => {
-						for (const s of stmts) ops.push(s);
+						for (const s of stmts) {
+							if (typeof s.sql === 'string') ops.push(s);
+						}
 						return stmts.map(() => ({ meta: { changes: 1 } }));
 					}
 				}
@@ -452,26 +592,12 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		const insertedIds = ops
 			.filter((stmt) => typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content'))
 			.map((stmt) => stmt.args[3]);
-		// All 3 newly-inserted sections must come from the fresh ID range (>= 50000),
-		// not the overflowed [200, …] range that would risk cross-speech UNIQUE PK collision.
-		expect(insertedIds.length).toBeGreaterThanOrEqual(3);
-		for (const id of insertedIds) {
-			expect(id).toBeGreaterThanOrEqual(50000);
-		}
-		// Specifically should be 50000, 50001, 50002 (sequential from freshIdStart).
-		expect(insertedIds.slice(0, 3)).toEqual([50000, 50001, 50002]);
+		expect(insertedIds).toEqual([50000, 50001, 50002]);
 	});
 
 	it('allocates fresh global ids (not base+1) when the anchor is already a sub-section id', async () => {
-		// Regression: the EN "Outrage to Overlap" speech was left with 8-digit
-		// sub-section ids (e.g. 63852882). On PATCH, inserting after such an anchor
-		// took the `fallbackBase + 1` branch and walked 63852883, 63852884, … —
-		// ids that sit *below* the global MAX(section_id) counter and are owned by
-		// OTHER speeches, so the INSERT hit "UNIQUE constraint failed:
-		// speech_content.section_id" (surfaced as HTTP 503). loadConflictingSubSectionIds
-		// only pre-blocks [min*100+1, max*100+99] (a far-away ~10-digit window here) and
-		// misses the +1 zone, so anchorId+1 was chosen and collided. The fix forces a
-		// sub-section anchor to allocate fresh global ids.
+		// Regression guard for old sub-section-like ids. Inserted sections must come
+		// from the reserved global block, never anchorId+1.
 		const ops: any[] = [];
 		const requestBody = {
 			filename: 'sub-anchor-insert',
@@ -498,12 +624,10 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 				return { success: true, results: [{ speaker_route_pathname: 'A' }] };
 			}
 			if (sql.includes('SELECT section_id FROM speech_content WHERE filename != ?')) {
-				// loadConflictingSubSectionIds queries the far-away ~10-digit window and
-				// finds nothing — so anchorId+1 (63852883) is NOT pre-blocked.
 				return { success: true, results: [] };
 			}
-			if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
-				return { success: true, results: [{ max_id: 70000000 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(70000000, args);
 			}
 			return { success: true, results: [] };
 		};
@@ -523,7 +647,14 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						const run = (args: unknown[]) => ({
 							sql,
 							args,
-							first: async () => resolver(sql, args).results[0] ?? null,
+							first: async () => {
+								const row = resolver(sql, args).results[0];
+								if (row != null) return row;
+								if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+									return { next_id: 1 + Number(args[0] || 1) };
+								}
+								return null;
+							},
 							all: async () => {
 								const r = resolver(sql, args);
 								return { success: r.success ?? true, results: r.results };
@@ -538,7 +669,9 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						};
 					},
 					batch: async (stmts: any[]) => {
-						for (const s of stmts) ops.push(s);
+						for (const s of stmts) {
+							if (typeof s.sql === 'string') ops.push(s);
+						}
 						return stmts.map(() => ({ meta: { changes: 1 } }));
 					}
 				}
@@ -571,22 +704,15 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		expect(insertedIds[0]).toBe(70000001);
 	});
 
-	it('allocateFresh skips freshIdRef.value when it collides with usedIds', async () => {
-		// 防禦性測試：當 freshIdRef.value（globalMax+1）剛好落在 usedIds 內時，
-		// allocateFresh 的 `while (usedIds.has(freshIdRef.value)) freshIdRef.value += 1`
-		// 必須跳過該 ID。實務上 DB 狀態一致時不會發生，但 inconsistency / race
-		// 仍可能讓 freshIdStart 撞上 oldRows.section_id，這支 while 是最後一道防線。
+	it('reservation starts above existing section ids even when the counter was stale', async () => {
 		const ops: any[] = [];
 		const requestBody = {
 			filename: 'fresh-collision',
 			markdown: '# X\n## A:\nanchor\n\nins1\n\nins2'
 		};
-		// 老 section id = 1，所以 usedIds 起始 = {1}。
 		const oldSections = [
 			{ section_id: 1, previous_section_id: null, next_section_id: null, section_speaker: 'A', section_content: '<p>anchor</p>' }
 		];
-		// 把 sub-section slot [101, 199] 全部佔住，逼 nextCandidate 溢出 safeRangeMax(=199)。
-		const fullyBlockedRange = Array.from({ length: 99 }, (_, i) => ({ section_id: 101 + i }));
 		const resolver: Resolver = (sql, args) => {
 			if (sql.includes('FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: args[0] === requestBody.filename
@@ -606,12 +732,8 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
 				return { success: true, results: [{ speaker_route_pathname: 'A' }] };
 			}
-			if (sql.includes('SELECT section_id FROM speech_content WHERE filename != ?')) {
-				return { success: true, results: fullyBlockedRange };
-			}
-			if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
-				// 故意讓 freshIdStart = 0+1 = 1 撞上 oldSections[0].section_id。
-				return { success: true, results: [{ max_id: 0 }] };
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(1, args);
 			}
 			return { success: true, results: [] };
 		};
@@ -631,7 +753,14 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						const run = (args: unknown[]) => ({
 							sql,
 							args,
-							first: async () => resolver(sql, args).results[0] ?? null,
+							first: async () => {
+								const row = resolver(sql, args).results[0];
+								if (row != null) return row;
+								if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+									return { next_id: 1 + Number(args[0] || 1) };
+								}
+								return null;
+							},
 							all: async () => {
 								const r = resolver(sql, args);
 								return { success: r.success ?? true, results: r.results };
@@ -646,7 +775,9 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						};
 					},
 					batch: async (stmts: any[]) => {
-						for (const s of stmts) ops.push(s);
+						for (const s of stmts) {
+							if (typeof s.sql === 'string') ops.push(s);
+						}
 						return stmts.map(() => ({ meta: { changes: 1 } }));
 					}
 				}
@@ -670,20 +801,13 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		const insertedIds = ops
 			.filter((stmt) => typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content'))
 			.map((stmt) => stmt.args[3]);
-		// allocateFresh 第一次 freshIdRef.value=1 撞 usedIds 跳到 2；之後依序給 3, …
-		// 不能拿到 1（會撞 oldSections）也不能落在 [101,199]（被別篇 speech 佔走）。
 		expect(insertedIds).not.toContain(1);
-		for (const id of insertedIds) {
-			expect(id < 101 || id > 199).toBe(true);
-		}
-		expect(insertedIds).toContain(2);
+		expect(insertedIds).toEqual([2, 3]);
 	});
 
-	it('skips over a sub-section id already used by ANOTHER speech (cross-filename UNIQUE PK guard)', async () => {
-		// Old section id 1 → first sub-id candidate would be 101. If another speech in
-		// speech_content already owns 101, the INSERT would otherwise hit
-		// "UNIQUE constraint failed: speech_content.section_id". loadConflictingSubSectionIds
-		// should pre-fetch that 101 and append it to usedIds, so the inserter advances to 102.
+	it('allocates a fresh id beyond another speech collision candidate', async () => {
+		// Another speech already owns what the old positional scheme would have used.
+		// The new contract allocates from the global reserved block instead.
 		const ops: any[] = [];
 		const requestBody = {
 			filename: 'cross-collision',
@@ -716,6 +840,9 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 				// Another speech already owns 101 in the candidate range.
 				return { success: true, results: [{ section_id: 101 }] };
 			}
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return reservedCounterResult(200, args);
+			}
 			return { success: true, results: [] };
 		};
 
@@ -734,7 +861,14 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						const run = (args: unknown[]) => ({
 							sql,
 							args,
-							first: async () => resolver(sql, args).results[0] ?? null,
+							first: async () => {
+								const row = resolver(sql, args).results[0];
+								if (row != null) return row;
+								if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+									return { next_id: 1 + Number(args[0] || 1) };
+								}
+								return null;
+							},
 							all: async () => {
 								const r = resolver(sql, args);
 								return { success: r.success ?? true, results: r.results };
@@ -749,7 +883,9 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 						};
 					},
 					batch: async (stmts: any[]) => {
-						for (const s of stmts) ops.push(s);
+						for (const s of stmts) {
+							if (typeof s.sql === 'string') ops.push(s);
+						}
 						return stmts.map(() => ({ meta: { changes: 1 } }));
 					}
 				}
@@ -773,9 +909,8 @@ describe('assignPatchedSections branches — many inserted sections', () => {
 		const insertedIds = ops
 			.filter((stmt) => typeof stmt.sql === 'string' && stmt.sql.startsWith('INSERT INTO speech_content'))
 			.map((stmt) => stmt.args[3]);
-		// 101 is blocked by another filename → inserter must skip to 102
 		expect(insertedIds).not.toContain(101);
-		expect(insertedIds).toContain(102);
+		expect(insertedIds).toEqual([201]);
 	});
 });
 
@@ -800,14 +935,18 @@ describe('PATCH treats svg / iframe blocks as match anchors (issue #68)', () => 
 			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
 				return { success: true, results: [{ speaker_route_pathname: 'A' }] };
 			}
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				const maxSectionId = Math.max(0, ...oldSections.map((section) => Number(section.section_id) || 0));
+				return reservedCounterResult(maxSectionId, args);
+			}
 			return { success: true, results: [] };
 		};
 	}
 
 	it('preserves the svg section_id when prose is inserted before it and inner svg markup changes', async () => {
 		// Without #68: LCS only matches the intro; gap-pairing makes the new prose inherit the svg's
-		// old id, and the new svg is allocated a sub-id. With #68: svg is treated as an anchor in LCS,
-		// so the new prose gets the sub-id and the svg keeps its original section_id.
+		// old id. With #68: svg is treated as an anchor in LCS, so the new prose gets
+		// a fresh reserved id and the svg keeps its original section_id.
 		const oldSections = [
 			{ section_id: 100, previous_section_id: null, next_section_id: 200, section_speaker: 'A', section_content: '<p>Intro paragraph here.</p>' },
 			{ section_id: 200, previous_section_id: 100, next_section_id: null, section_speaker: 'A', section_content: '<svg viewBox="0 0 100 100"><title>Old Chart</title><circle/></svg>' }
@@ -850,6 +989,7 @@ describe('PATCH treats svg / iframe blocks as match anchors (issue #68)', () => 
 		});
 		expect(explanationInsert).toBeDefined();
 		expect((explanationInsert!.args as any[])[3]).not.toBe(200);
+		expect((explanationInsert!.args as any[])[3]).toBeGreaterThan(200);
 	});
 
 	it('preserves the iframe section_id when iframe src changes and an unrelated section is inserted', async () => {
@@ -882,6 +1022,14 @@ describe('PATCH treats svg / iframe blocks as match anchors (issue #68)', () => 
 		const iframeContent = (iframeUpdate!.args as any[])[3] as string;
 		expect(iframeContent).toContain('<iframe');
 		expect(iframeContent).toContain('new.example.com');
+		const insertOps = env.__operations.filter((s) => s.sql.startsWith('INSERT INTO speech_content'));
+		const noteInsert = insertOps.find((s) => {
+			const content = (s.args as any[])[7];
+			return typeof content === 'string' && content.includes('A note added between');
+		});
+		expect(noteInsert).toBeDefined();
+		expect((noteInsert!.args as any[])[3]).not.toBe(300);
+		expect((noteInsert!.args as any[])[3]).toBeGreaterThan(300);
 	});
 
 	it('does NOT short-circuit when a section mixes iframe with surrounding prose', async () => {

--- a/test/upload_markdown_patch.spec.ts
+++ b/test/upload_markdown_patch.spec.ts
@@ -44,8 +44,8 @@ function createUpsertEnv(options: {
 		if (sql.includes('SELECT COUNT(*) AS count FROM speech_content')) {
 			return { success: true, results: [{ count: 0 }] };
 		}
-		if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
-			return { success: true, results: [{ max_id: 500 }] };
+		if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+			return { success: true, results: [{ next_id: 501 + Number(args[0] || 1) }] };
 		}
 		if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
 			return { success: true, results: [] };
@@ -114,7 +114,7 @@ function createUpsertEnv(options: {
 			},
 			batch: async (statements: PreparedStatement[]) => {
 				for (const stmt of statements) {
-					operations.push(stmt);
+					if (typeof stmt.sql === 'string') operations.push(stmt);
 				}
 				return statements.map(() => ({ meta: { changes: 1 } }));
 			}

--- a/test/upload_markdown_post.spec.ts
+++ b/test/upload_markdown_post.spec.ts
@@ -23,8 +23,8 @@ function createPostEnv(options: { hasExistingFilename?: boolean; redirects?: Rec
 		if (sql.includes('FROM speech_index WHERE filename = ?')) {
 			return { success: true, results: [] };
 		}
-		if (sql.includes('SELECT MAX(section_id) AS max_id FROM speech_content')) {
-			return { success: true, results: [{ max_id: 1000 }] };
+		if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+			return { success: true, results: [{ next_id: 1001 + Number(args[0] || 1) }] };
 		}
 		if (sql.includes('SELECT COUNT(*) AS count FROM speech_index')) {
 			return { success: true, results: [{ count: 1 }] };
@@ -85,7 +85,7 @@ function createPostEnv(options: { hasExistingFilename?: boolean; redirects?: Rec
 			},
 			batch: async (statements: PreparedStatement[]) => {
 				for (const stmt of statements) {
-					operations.push(stmt);
+					if (typeof stmt.sql === 'string') operations.push(stmt);
 				}
 				return statements.map(() => ({ meta: { changes: 1 } }));
 			}

--- a/test/upload_markdown_reserve.spec.ts
+++ b/test/upload_markdown_reserve.spec.ts
@@ -1,0 +1,53 @@
+import { createExecutionContext } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import worker from '../src/index';
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+/**
+ * reserveSectionIds() throws when the atomic `UPDATE section_id_counter ...
+ * RETURNING next_id` yields no row (e.g. a transient D1 fault). The handler must
+ * surface that as HTTP 503, not allocate ids from a bad/NaN counter value.
+ */
+describe('reserveSectionIds failure handling', () => {
+	it('returns 503 when the counter reservation returns no row', async () => {
+		// Every query resolves to an empty result set, so the counter
+		// UPDATE ... RETURNING .first() returns null -> reserveSectionIds throws.
+		const query = () => ({ success: true, results: [] as any[] });
+
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'token-audrey',
+			BESTIAN_TRANSCRIPT_TOKEN: 'token-bestian',
+			ASSETS: { fetch: () => new Response('NF', { status: 404 }) },
+			SPEECH_CACHE: {
+				delete: async () => true,
+				get: async () => null,
+				put: async () => {},
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: (sql: string) => {
+					const statement = (args: unknown[] = []): any => ({
+						sql,
+						args,
+						bind: (...bound: unknown[]) => statement(bound),
+						first: async () => query().results[0] ?? null,
+						all: async () => query(),
+						run: async () => ({ success: true, meta: { changes: 1 } })
+					});
+					return statement();
+				},
+				batch: async (stmts: any[]) => stmts.map(() => ({ meta: { changes: 1 } }))
+			}
+		};
+
+		const req = new IncomingRequest('https://example.com/api/upload_markdown', {
+			method: 'POST',
+			headers: { Authorization: 'Bearer token-audrey', 'Content-Type': 'application/json' },
+			body: JSON.stringify({ filename: 'no-counter', markdown: '# Title\n\nhello world' })
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env as any, ctx);
+		expect(res.status).toBe(503);
+	});
+});


### PR DESCRIPTION
## Problem

`speech_content.section_id` is a **global `INTEGER PRIMARY KEY`**. The allocator had two distinct collision classes, both surfacing to the sync client as **HTTP 503 `UNIQUE constraint failed: speech_content.section_id`**:

1. **Positional inserts.** PATCH placed inserted sections at `base*100+N` ids that fall *below* the global counter and collide with **other speeches'** ids. PR #132 fixed only the large-anchor end; the symmetric small-anchor end remained open, and `loadConflictingSubSectionIds` could degrade into a tens-of-millions-row `BETWEEN` scan.
2. **Cross-request race.** POST and PATCH read `MAX(section_id)` then computed `MAX+1..` in JS before a *separate* INSERT, so two concurrent uploads (two uploader repos + `warm-cache` concurrency) minted the same ids → second commit 503s.

## Fix

`reserveSectionIds()` reserves a contiguous, collision-free id block in **one atomic statement**:

```sql
UPDATE section_id_counter
SET next_id = MAX(next_id, (SELECT COALESCE(MAX(section_id),0)+1 FROM speech_content)) + ?
WHERE id = 1
RETURNING next_id
```

SQLite serialises concurrent reservations into **disjoint** blocks (race gone), and the counter is always floored at `MAX(section_id)+1` (self-healing, so every reserved id is strictly greater than any existing row — collision-free by construction). All PATCH-inserted sections draw fresh ids from the reserved block; **LCS-matched sections keep their old ids** (deep-link/OG-cache stability). `section_id` becomes pure identity — display order is carried by the `previous/next` link chain (`sectionUtils`), so non-local fresh ids are fine.

Deletes the entire fragile machinery: `base*100+N`, `isSubSectionId`, `loadConflictingSubSectionIds`, `safeRangeMax`, the 99-insert cap and its 409. Net **−166/+96** in `upload_markdown.ts`.

### Read path

`buildSearchDocsForSpeech` loaded the full speech but concatenated blocks in raw `section_id` order, scrambling search excerpts once inserts get fresh (tail-sorted) ids. Now ordered via `normalizeSections` (the link chain), consistent with every other whole-speech read path.

> The remaining `section_id`-ordered read paths (paginated speaker page, and a few `MIN(section_id)` "first/representative section" picks in rss/og/nested-list) are heuristics that need an explicit `display_order` column to be perfectly correct under pagination — scoped as a separate follow-up, not bundled into this allocation fix.

## Tests

New race-immunity regression (disjoint id blocks across sequential POSTs); locality-specific tests rewritten to assert fresh sequential ids; the removed-99-cap test now asserts success. **Full suite green: 439 tests / 44 files.** `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)