### PR TITLE
feat(home): 整合 CAG 串流提問到首頁

### DIFF
--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -43,6 +43,23 @@
 	var askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
 	input.setAttribute('placeholder', askT.searchPlaceholder);
 	input.setAttribute('aria-label', askT.searchAriaLabel);
+	function refreshSearchI18n() {
+		isZh = document.documentElement.classList.contains('lang-zh');
+		askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
+		input.setAttribute('placeholder', askT.searchPlaceholder);
+		input.setAttribute('aria-label', askT.searchAriaLabel);
+		updateAskControls();
+	}
+
+	var searchSubmitButtons = document.querySelectorAll('.sayit-search__submit');
+	for (var si = 0; si < searchSubmitButtons.length; si++) {
+		searchSubmitButtons[si].addEventListener('click', function () {
+			submitSearch(input.value);
+		});
+	}
+	for (var sb = 0; sb < searchSubmitButtons.length; sb++) searchSubmitButtons[sb].hidden = false;
+
+	window.addEventListener('sayit-lang-change', refreshSearchI18n);
 
 	var worker = null;
 	var debounceTimer = null;
@@ -557,6 +574,7 @@
 			if (!data || data.status !== 'available') return;
 			askAvailable = true;
 			if (askPanel) askPanel.hidden = false;
+			for (var sb = 0; sb < searchSubmitButtons.length; sb++) searchSubmitButtons[sb].hidden = false;
 			updateAskControls();
 		}).catch(function () {
 			askAvailable = false;

--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -7,13 +7,41 @@
 	var speechList = document.getElementById('sayit-speech-list');
 	var askPanel = document.getElementById('sayit-ask');
 	var askSubmit = document.getElementById('sayit-ask-submit');
+	var askConsent = document.getElementById('sayit-ask-consent');
 	var askStatus = document.getElementById('sayit-ask-status');
 	var askAnswer = document.getElementById('sayit-ask-answer');
 	if (!input || !results) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
-	input.setAttribute('placeholder', isZh ? '搜尋對話內容…' : 'Search speeches…');
-	if (isZh) input.setAttribute('aria-label', '搜尋對話');
+	var ASK_STRINGS = {
+		zh: {
+			searchPlaceholder: '搜尋對話內容…',
+			searchAriaLabel: '搜尋對話',
+			submit: '💬 提問',
+			submitting: '💬 提問中…',
+			cooldown: function (seconds) { return '💬 ' + seconds + ' 秒後可再提問'; },
+			searching: '檢索逐字稿中…',
+			sourcesHeading: '出處',
+			questionTooLong: '問題太長，請縮短到 100 字以內。',
+			fetchError: '提問服務暫時無法使用，請稍後再試。',
+			networkError: '連線發生錯誤，請稍後再試。',
+		},
+		en: {
+			searchPlaceholder: 'Search speeches…',
+			searchAriaLabel: 'Search speeches',
+			submit: '💬 Ask',
+			submitting: '💬 Asking…',
+			cooldown: function (seconds) { return '💬 Ask again in ' + seconds + ' s'; },
+			searching: 'Searching the transcripts…',
+			sourcesHeading: 'Sources',
+			questionTooLong: 'Your question is too long. Please shorten it to 100 characters or fewer.',
+			fetchError: 'The ask service is temporarily unavailable. Please try again later.',
+			networkError: 'Connection error. Please try again later.',
+		},
+	};
+	var askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
+	input.setAttribute('placeholder', askT.searchPlaceholder);
+	input.setAttribute('aria-label', askT.searchAriaLabel);
 
 	var worker = null;
 	var debounceTimer = null;
@@ -179,18 +207,25 @@
 		if (askStatus) askStatus.textContent = message || '';
 	}
 
+	function consentAccepted() {
+		return askConsent ? askConsent.checked : false;
+	}
+
 	function updateAskControls() {
-		if (!askPanel || !askSubmit) return;
+		if (!askSubmit) return;
 		var hasQuestion = Boolean(input.value.trim());
 		var disabled = askLoading || askCooldownRemaining > 0;
-		askSubmit.disabled = disabled || !hasQuestion;
+		var canAsk = consentAccepted();
+		askSubmit.disabled = disabled || !hasQuestion || !canAsk;
 		askSubmit.textContent = askLoading
-			? '💬 提問中…'
-			: (askCooldownRemaining > 0 ? '💬 ' + askCooldownRemaining + ' 秒後可再提問' : '💬 提問');
+			? askT.submitting
+			: (askCooldownRemaining > 0 ? askT.cooldown(askCooldownRemaining) : askT.submit);
+		if (askConsent) askConsent.disabled = askLoading;
 
+		if (!askPanel) return;
 		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
 		for (var i = 0; i < samples.length; i++) {
-			samples[i].disabled = disabled;
+			samples[i].disabled = disabled || !canAsk;
 		}
 	}
 
@@ -224,7 +259,7 @@
 		var parsed = parseAskAnswer(raw);
 		var html = '';
 		if (!parsed.html && loading) {
-			html += '<p class="homepage-ask-answer__status">檢索逐字稿中…</p>';
+			html += '<p class="homepage-ask-answer__status">' + escapeHtml(askT.searching) + '</p>';
 		}
 		if (parsed.html) {
 			html += '<div class="homepage-ask-answer__body">' + parsed.html + '</div>';
@@ -233,7 +268,7 @@
 			html += '<span class="homepage-ask-answer__cursor" aria-hidden="true">▌</span>';
 		}
 		if (parsed.sources.length > 0) {
-			html += '<div class="homepage-ask-answer__sources"><h3>出處</h3><ol>';
+			html += '<div class="homepage-ask-answer__sources"><h3>' + escapeHtml(askT.sourcesHeading) + '</h3><ol>';
 			for (var i = 0; i < parsed.sources.length; i++) {
 				var source = parsed.sources[i];
 				html += '<li value="' + source.index + '"><a href="' + escapeHtml(source.href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(source.label) + '</a></li>';
@@ -440,7 +475,8 @@
 	}
 
 	function askEndpointForQuestion(question) {
-		return ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+		var endpoint = ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+		return isZh ? endpoint : endpoint + '?lang=en';
 	}
 
 	function parseRetryAfter(response) {
@@ -450,9 +486,9 @@
 
 	function runAsk(question) {
 		var query = (question || '').trim();
-		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0) return;
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return;
 		if (query.length > 100) {
-			renderAskAnswer('', false, '問題太長，請縮短到 100 字以內。');
+			renderAskAnswer('', false, askT.questionTooLong);
 			return;
 		}
 
@@ -472,7 +508,7 @@
 				return response.text().then(function (text) {
 					var retryAfter = parseRetryAfter(response);
 					if (response.status === 429 && retryAfter > 0) startAskCooldown(retryAfter);
-					throw new Error(text || '提問服務暫時無法使用，請稍後再試。');
+					throw new Error(text || askT.fetchError);
 				});
 			}
 
@@ -502,7 +538,7 @@
 			return readNext();
 		}).catch(function (error) {
 			if (error && error.name === 'AbortError') return;
-			renderAskAnswer('', false, error && error.message ? error.message : '連線發生錯誤，請稍後再試。');
+			renderAskAnswer('', false, error && error.message ? error.message : askT.networkError);
 		}).finally(function () {
 			setAskLoading(false);
 			askAbortController = null;
@@ -510,7 +546,7 @@
 	}
 
 	function initAsk() {
-		if (!askPanel || !askSubmit || !askAnswer || !window.fetch) return;
+		if (!askSubmit || !askAnswer || !window.fetch) return;
 
 		fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
 			if (!response.ok) throw new Error('capacity unavailable');
@@ -518,7 +554,8 @@
 		}).then(function (data) {
 			if (!data || data.status !== 'available') return;
 			askAvailable = true;
-			askPanel.hidden = false;
+			if (askPanel) askPanel.hidden = false;
+			askSubmit.hidden = false;
 			updateAskControls();
 		}).catch(function () {
 			askAvailable = false;
@@ -528,6 +565,13 @@
 			runAsk(input.value);
 		});
 
+		if (askConsent) {
+			askConsent.addEventListener('change', function () {
+				updateAskControls();
+			});
+		}
+
+		if (!askPanel) return;
 		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
 		for (var i = 0; i < samples.length; i++) {
 			samples[i].addEventListener('click', function (event) {

--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -9,6 +9,8 @@
 	var askSubmit = document.getElementById('sayit-ask-submit');
 		var askStatus = document.getElementById('sayit-ask-status');
 	var askAnswer = document.getElementById('sayit-ask-answer');
+	var lastAskMarkdown = '';
+	var askCopyResetTimer = null;
 	if (!input) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
@@ -21,6 +23,9 @@
 			cooldown: function (seconds) { return '💬 ' + seconds + ' 秒後可再提問'; },
 			searching: '檢索逐字稿中…',
 			sourcesHeading: '出處',
+			copyMarkdown: '複製 Markdown',
+			copiedMarkdown: '已複製',
+			copyFailed: '無法複製，請手動選取文字',
 			questionTooLong: '問題太長，請縮短到 100 字以內。',
 			fetchError: '提問服務暫時無法使用，請稍後再試。',
 			networkError: '連線發生錯誤，請稍後再試。',
@@ -34,6 +39,9 @@
 			cooldown: function (seconds) { return '💬 Ask again in ' + seconds + ' s'; },
 			searching: 'Searching the transcripts…',
 			sourcesHeading: 'Sources',
+			copyMarkdown: 'Copy Markdown',
+			copiedMarkdown: 'Copied',
+			copyFailed: 'Could not copy. Select the answer and copy manually.',
 			questionTooLong: 'Your question is too long. Please shorten it to 100 characters or fewer.',
 			fetchError: 'The ask service is temporarily unavailable. Please try again later.',
 			networkError: 'Connection error. Please try again later.',
@@ -169,6 +177,55 @@
 		return doc.body.innerHTML;
 	}
 
+
+	function askHasVisibleAnswer() {
+		return !!(askAnswer && !askAnswer.hidden && (lastAskMarkdown || '').trim());
+	}
+
+	function copyMarkdownText(text) {
+		if (!text) return Promise.resolve(false);
+		try {
+			if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+				return navigator.clipboard.writeText(text).then(function () { return true; }).catch(function () { return false; });
+			}
+		} catch (e) {}
+		try {
+			var textarea = document.createElement('textarea');
+			textarea.value = text;
+			textarea.setAttribute('readonly', '');
+			textarea.style.position = 'fixed';
+			textarea.style.inset = '0 auto auto 0';
+			textarea.style.opacity = '0';
+			document.body.appendChild(textarea);
+			textarea.focus();
+			textarea.select();
+			var ok = document.execCommand('copy');
+			textarea.remove();
+			return Promise.resolve(!!ok);
+		} catch (err) {
+			return Promise.resolve(false);
+		}
+	}
+
+	function bindAskCopyButton() {
+		if (!askAnswer || askAnswer.dataset.sayitCopyBound) return;
+		askAnswer.dataset.sayitCopyBound = '1';
+		askAnswer.addEventListener('click', function (e) {
+			var btn = e.target && e.target.closest ? e.target.closest('[data-sayit-ask-copy]') : null;
+			if (!btn || btn.disabled) return;
+			var text = lastAskMarkdown || '';
+			if (!text.trim()) return;
+			copyMarkdownText(text).then(function (ok) {
+				btn.textContent = ok ? askT.copiedMarkdown : askT.copyFailed;
+				if (askCopyResetTimer) clearTimeout(askCopyResetTimer);
+				askCopyResetTimer = setTimeout(function () {
+					btn.textContent = askT.copyMarkdown;
+					askCopyResetTimer = null;
+				}, 2000);
+			});
+		});
+	}
+
 	function parseAskAnswer(raw) {
 		var sources = [];
 		var seen = {};
@@ -221,6 +278,7 @@
 		if (!askAnswer) return;
 		askAnswer.hidden = true;
 		askAnswer.innerHTML = '';
+		lastAskMarkdown = '';
 	}
 
 	function setAskStatus(message) {
@@ -269,14 +327,20 @@
 
 	function renderAskAnswer(raw, loading, error) {
 		if (!askAnswer) return;
+		bindAskCopyButton();
 		askAnswer.hidden = false;
 		if (error) {
+			lastAskMarkdown = '';
 			askAnswer.innerHTML = '<p class="homepage-ask-answer__error">' + sanitizeHtml(escapeHtml(error)) + '</p>';
 			return;
 		}
 
+		lastAskMarkdown = raw || '';
 		var parsed = parseAskAnswer(raw);
 		var html = '';
+		if ((raw || '').trim()) {
+			html += '<div class="homepage-ask-answer__toolbar"><button type="button" class="homepage-ask-answer__copy" data-sayit-ask-copy aria-label="' + escapeHtml(askT.copyMarkdown) + '">' + escapeHtml(askT.copyMarkdown) + '</button></div>';
+		}
 		if (!parsed.html && loading) {
 			html += '<p class="homepage-ask-answer__status">' + escapeHtml(askT.searching) + '</p>';
 		}
@@ -476,7 +540,8 @@
 			}
 
 			if (!msg.results || msg.results.length === 0) {
-				renderNoResults(query);
+				if (!askHasVisibleAnswer()) renderNoResults(query);
+				else hideResults();
 				return;
 			}
 

--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -5,6 +5,10 @@
 	var results = document.getElementById('sayit-search-results');
 	var shortcutBadge = document.getElementById('sayit-search-shortcut');
 	var speechList = document.getElementById('sayit-speech-list');
+	var askPanel = document.getElementById('sayit-ask');
+	var askSubmit = document.getElementById('sayit-ask-submit');
+	var askStatus = document.getElementById('sayit-ask-status');
+	var askAnswer = document.getElementById('sayit-ask-answer');
 	if (!input || !results) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
@@ -20,6 +24,12 @@
 	var requestId = 0;
 	var pendingResolves = {};
 	var workerWarmed = false;
+	var askAvailable = false;
+	var askLoading = false;
+	var askCooldownTimer = null;
+	var askCooldownRemaining = 0;
+	var askAbortController = null;
+	var ASK_BASE_URL = 'https://ask.archive.tw';
 
 	function shouldWarmupOnFocus() {
 		var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
@@ -73,6 +83,79 @@
 		return textarea.value;
 	}
 
+	function isSafeHttpUrl(value) {
+		if (/[\s"'<>]/.test(value) || /&(quot|#39|lt|gt);/i.test(value)) return false;
+		try {
+			var url = new URL(value);
+			return url.protocol === 'http:' || url.protocol === 'https:';
+		} catch (e) {
+			return false;
+		}
+	}
+
+	function sanitizeHtml(html) {
+		var doc = new DOMParser().parseFromString(html, 'text/html');
+		var blocked = doc.body.querySelectorAll('script, iframe, object, embed, base, meta, link');
+		for (var i = 0; i < blocked.length; i++) blocked[i].remove();
+
+		var walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
+		var element = walker.nextNode();
+		while (element) {
+			var attrs = Array.prototype.slice.call(element.attributes);
+			for (var j = 0; j < attrs.length; j++) {
+				var attr = attrs[j];
+				var name = attr.name.toLowerCase();
+				if (name.indexOf('on') === 0 || name === 'srcdoc' || name === 'style') {
+					element.removeAttribute(attr.name);
+					continue;
+				}
+				if (/^(href|src|xlink:href|action|formaction|poster)$/i.test(name) && !isSafeHttpUrl(attr.value)) {
+					element.removeAttribute(attr.name);
+				}
+			}
+			if (element.tagName.toLowerCase() === 'a') {
+				element.setAttribute('target', '_blank');
+				element.setAttribute('rel', 'nofollow noopener noreferrer');
+			}
+			element = walker.nextNode();
+		}
+
+		return doc.body.innerHTML;
+	}
+
+	function parseAskAnswer(raw) {
+		var sources = [];
+		var seen = {};
+		var body = (raw || '').replace(/^\[\^(\d+)\]:\s*\[([^\]]*)\]\(([^)\s]+)\)\s*$/gm, function (_m, num, label, href) {
+			if (!isSafeHttpUrl(href)) return '';
+			var index = Number(num);
+			if (!seen[index]) {
+				seen[index] = true;
+				sources.push({ index: index, label: label.trim() || href, href: href });
+			}
+			return '';
+		}).trim();
+		sources.sort(function (a, b) { return a.index - b.index; });
+
+		var hrefByIndex = {};
+		for (var i = 0; i < sources.length; i++) hrefByIndex[sources[i].index] = sources[i].href;
+
+		var html = escapeHtml(body);
+		html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+		html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+		html = html.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, function (_m, label, href) {
+			if (!isSafeHttpUrl(href)) return escapeHtml(label);
+			return '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(label) + '</a>';
+		});
+		html = html.replace(/\[\^(\d+)\]/g, function (m, num) {
+			var href = hrefByIndex[Number(num)];
+			if (!href) return '';
+			return '<sup class="cite"><a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">[' + escapeHtml(num) + ']</a></sup>';
+		});
+
+		return { html: sanitizeHtml(html), sources: sources };
+	}
+
 	function showResults() {
 		results.hidden = false;
 		if (speechList) speechList.style.display = 'none';
@@ -84,6 +167,80 @@
 		if (speechList) speechList.style.display = '';
 		currentSearchResults = null;
 		displayedCount = 0;
+	}
+
+	function hideAskAnswer() {
+		if (!askAnswer) return;
+		askAnswer.hidden = true;
+		askAnswer.innerHTML = '';
+	}
+
+	function setAskStatus(message) {
+		if (askStatus) askStatus.textContent = message || '';
+	}
+
+	function updateAskControls() {
+		if (!askPanel || !askSubmit) return;
+		var hasQuestion = Boolean(input.value.trim());
+		var disabled = askLoading || askCooldownRemaining > 0;
+		askSubmit.disabled = disabled || !hasQuestion;
+		askSubmit.textContent = askLoading
+			? '💬 提問中…'
+			: (askCooldownRemaining > 0 ? '💬 ' + askCooldownRemaining + ' 秒後可再提問' : '💬 提問');
+
+		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
+		for (var i = 0; i < samples.length; i++) {
+			samples[i].disabled = disabled;
+		}
+	}
+
+	function startAskCooldown(seconds) {
+		askCooldownRemaining = Math.max(0, Number(seconds) || 0);
+		if (askCooldownTimer) clearInterval(askCooldownTimer);
+		if (askCooldownRemaining <= 0) {
+			updateAskControls();
+			return;
+		}
+		updateAskControls();
+		askCooldownTimer = setInterval(function () {
+			askCooldownRemaining -= 1;
+			if (askCooldownRemaining <= 0) {
+				askCooldownRemaining = 0;
+				clearInterval(askCooldownTimer);
+				askCooldownTimer = null;
+			}
+			updateAskControls();
+		}, 1000);
+	}
+
+	function renderAskAnswer(raw, loading, error) {
+		if (!askAnswer) return;
+		askAnswer.hidden = false;
+		if (error) {
+			askAnswer.innerHTML = '<p class="homepage-ask-answer__error">' + sanitizeHtml(escapeHtml(error)) + '</p>';
+			return;
+		}
+
+		var parsed = parseAskAnswer(raw);
+		var html = '';
+		if (!parsed.html && loading) {
+			html += '<p class="homepage-ask-answer__status">檢索逐字稿中…</p>';
+		}
+		if (parsed.html) {
+			html += '<div class="homepage-ask-answer__body">' + parsed.html + '</div>';
+		}
+		if (loading) {
+			html += '<span class="homepage-ask-answer__cursor" aria-hidden="true">▌</span>';
+		}
+		if (parsed.sources.length > 0) {
+			html += '<div class="homepage-ask-answer__sources"><h3>出處</h3><ol>';
+			for (var i = 0; i < parsed.sources.length; i++) {
+				var source = parsed.sources[i];
+				html += '<li value="' + source.index + '"><a href="' + escapeHtml(source.href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(source.label) + '</a></li>';
+			}
+			html += '</ol></div>';
+		}
+		askAnswer.innerHTML = html;
 	}
 
 	function renderLoading() {
@@ -247,6 +404,7 @@
 			return;
 		}
 
+		hideAskAnswer();
 		currentQuery = query;
 		currentSearchResults = null;
 		displayedCount = 0;
@@ -276,11 +434,116 @@
 		});
 	}
 
+	function setAskLoading(value) {
+		askLoading = value;
+		updateAskControls();
+	}
+
+	function askEndpointForQuestion(question) {
+		return ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+	}
+
+	function parseRetryAfter(response) {
+		var retryAfter = Number(response.headers.get('Retry-After'));
+		return Number.isFinite(retryAfter) && retryAfter > 0 ? Math.ceil(retryAfter) : 0;
+	}
+
+	function runAsk(question) {
+		var query = (question || '').trim();
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0) return;
+		if (query.length > 100) {
+			renderAskAnswer('', false, '問題太長，請縮短到 100 字以內。');
+			return;
+		}
+
+		input.value = query;
+		currentQuery = '';
+		clearTimeout(debounceTimer);
+		hideResults();
+		setAskStatus('');
+		renderAskAnswer('', true, '');
+		setAskLoading(true);
+
+		if (askAbortController) askAbortController.abort();
+		askAbortController = new AbortController();
+
+		fetch(askEndpointForQuestion(query), { signal: askAbortController.signal }).then(function (response) {
+			if (!response.ok) {
+				return response.text().then(function (text) {
+					var retryAfter = parseRetryAfter(response);
+					if (response.status === 429 && retryAfter > 0) startAskCooldown(retryAfter);
+					throw new Error(text || '提問服務暫時無法使用，請稍後再試。');
+				});
+			}
+
+			if (!response.body || !response.body.getReader) {
+				return response.text().then(function (text) {
+					renderAskAnswer(text, false, '');
+				});
+			}
+
+			var reader = response.body.getReader();
+			var decoder = new TextDecoder();
+			var raw = '';
+
+			function readNext() {
+				return reader.read().then(function (chunk) {
+					if (chunk.done) {
+						raw += decoder.decode();
+						renderAskAnswer(raw, false, '');
+						return;
+					}
+					raw += decoder.decode(chunk.value, { stream: true });
+					renderAskAnswer(raw, true, '');
+					return readNext();
+				});
+			}
+
+			return readNext();
+		}).catch(function (error) {
+			if (error && error.name === 'AbortError') return;
+			renderAskAnswer('', false, error && error.message ? error.message : '連線發生錯誤，請稍後再試。');
+		}).finally(function () {
+			setAskLoading(false);
+			askAbortController = null;
+		});
+	}
+
+	function initAsk() {
+		if (!askPanel || !askSubmit || !askAnswer || !window.fetch) return;
+
+		fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
+			if (!response.ok) throw new Error('capacity unavailable');
+			return response.json();
+		}).then(function (data) {
+			if (!data || data.status !== 'available') return;
+			askAvailable = true;
+			askPanel.hidden = false;
+			updateAskControls();
+		}).catch(function () {
+			askAvailable = false;
+		});
+
+		askSubmit.addEventListener('click', function () {
+			runAsk(input.value);
+		});
+
+		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
+		for (var i = 0; i < samples.length; i++) {
+			samples[i].addEventListener('click', function (event) {
+				var question = event.currentTarget.getAttribute('data-sayit-ask-question') || '';
+				runAsk(question);
+			});
+		}
+	}
+
 	input.addEventListener('input', function () {
 		clearTimeout(debounceTimer);
 		var query = input.value;
+		updateAskControls();
 		if (!query.trim()) {
 			hideResults();
+			hideAskAnswer();
 			currentQuery = '';
 			return;
 		}
@@ -294,8 +557,10 @@
 			input.value = '';
 			input.blur();
 			hideResults();
+			hideAskAnswer();
 			currentQuery = '';
 			clearTimeout(debounceTimer);
+			updateAskControls();
 		}
 	});
 
@@ -318,4 +583,6 @@
 	input.addEventListener('blur', function () {
 		if (shortcutBadge && !input.value) shortcutBadge.style.opacity = '1';
 	});
+
+	initAsk();
 })();

--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -25,6 +25,7 @@
 			questionTooLong: '問題太長，請縮短到 100 字以內。',
 			fetchError: '提問服務暫時無法使用，請稍後再試。',
 			networkError: '連線發生錯誤，請稍後再試。',
+			consentRequired: '請先同意隱私權政策和使用條款，再按 Enter 提問；一般搜尋結果仍會顯示。',
 		},
 		en: {
 			searchPlaceholder: 'Search speeches…',
@@ -37,6 +38,7 @@
 			questionTooLong: 'Your question is too long. Please shorten it to 100 characters or fewer.',
 			fetchError: 'The ask service is temporarily unavailable. Please try again later.',
 			networkError: 'Connection error. Please try again later.',
+			consentRequired: 'Please agree to the Privacy Policy and Terms of Use first to ask AI; regular search results will still show.',
 		},
 	};
 	var askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
@@ -439,7 +441,6 @@
 			return;
 		}
 
-		hideAskAnswer();
 		currentQuery = query;
 		currentSearchResults = null;
 		displayedCount = 0;
@@ -486,10 +487,10 @@
 
 	function runAsk(question) {
 		var query = (question || '').trim();
-		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return;
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return Promise.resolve();
 		if (query.length > 100) {
 			renderAskAnswer('', false, askT.questionTooLong);
-			return;
+			return Promise.resolve();
 		}
 
 		input.value = query;
@@ -503,7 +504,7 @@
 		if (askAbortController) askAbortController.abort();
 		askAbortController = new AbortController();
 
-		fetch(askEndpointForQuestion(query), { signal: askAbortController.signal }).then(function (response) {
+		return fetch(askEndpointForQuestion(query), { signal: askAbortController.signal }).then(function (response) {
 			if (!response.ok) {
 				return response.text().then(function (text) {
 					var retryAfter = parseRetryAfter(response);
@@ -546,9 +547,9 @@
 	}
 
 	function initAsk() {
-		if (!askSubmit || !askAnswer || !window.fetch) return;
+		if (!askSubmit || !askAnswer || !window.fetch) return Promise.resolve();
 
-		fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
+		var capacityPromise = fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
 			if (!response.ok) throw new Error('capacity unavailable');
 			return response.json();
 		}).then(function (data) {
@@ -562,7 +563,7 @@
 		});
 
 		askSubmit.addEventListener('click', function () {
-			runAsk(input.value);
+			submitSearch(input.value);
 		});
 
 		if (askConsent) {
@@ -571,14 +572,46 @@
 			});
 		}
 
-		if (!askPanel) return;
-		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
-		for (var i = 0; i < samples.length; i++) {
-			samples[i].addEventListener('click', function (event) {
-				var question = event.currentTarget.getAttribute('data-sayit-ask-question') || '';
-				runAsk(question);
-			});
+		if (askPanel) {
+			var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
+			for (var i = 0; i < samples.length; i++) {
+				samples[i].addEventListener('click', function (event) {
+					var question = event.currentTarget.getAttribute('data-sayit-ask-question') || '';
+					submitSearch(question);
+				});
+			}
 		}
+
+		return capacityPromise;
+	}
+
+	function submitSearch(query) {
+		var q = (query || '').trim();
+		if (!q) return;
+
+		var onSearchResults = window.location.pathname === '/search/';
+
+		if (askAnswer && askAvailable && consentAccepted() && q.length <= 100 && !askLoading && askCooldownRemaining <= 0) {
+			runAiFirstSearch(q, onSearchResults);
+			return;
+		}
+
+		if (askAnswer) {
+			if (askAvailable && !consentAccepted() && q.length <= 100) setAskStatus(askT.consentRequired);
+			if (onSearchResults) return;
+			hideAskAnswer();
+			doSearch(q);
+			return;
+		}
+
+		window.location.assign('/search/?q=' + encodeURIComponent(query));
+	}
+
+	function runAiFirstSearch(query, skipRegularResults) {
+		hideResults();
+		return runAsk(query).then(function () {
+			if (!skipRegularResults) doSearch(query);
+		});
 	}
 
 	input.addEventListener('input', function () {
@@ -591,12 +624,16 @@
 			currentQuery = '';
 			return;
 		}
-		debounceTimer = setTimeout(function () {
-			doSearch(query);
-		}, 250);
 	});
 
 	input.addEventListener('keydown', function (e) {
+		if (e.key === 'Enter') {
+			if (e.isComposing || e.keyCode === 229) return;
+			if (e.metaKey || e.ctrlKey || e.altKey) return;
+			e.preventDefault();
+			submitSearch(input.value);
+			return;
+		}
 		if (e.key === 'Escape') {
 			input.value = '';
 			input.blur();
@@ -628,5 +665,12 @@
 		if (shortcutBadge && !input.value) shortcutBadge.style.opacity = '1';
 	});
 
-	initAsk();
+	initAsk().finally(function () {
+		if (!results || window.location.pathname !== '/search/') return;
+		var initialQuery = new URLSearchParams(window.location.search).get('q') || '';
+		if (!initialQuery.trim()) return;
+		input.value = initialQuery;
+		updateAskControls();
+		submitSearch(initialQuery);
+	});
 })();

--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -475,7 +475,7 @@
 	}
 
 	function askEndpointForQuestion(question) {
-		var endpoint = ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+		var endpoint = ASK_BASE_URL + '/au/' + encodeURIComponent(question);
 		return isZh ? endpoint : endpoint + '?lang=en';
 	}
 

--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -7,10 +7,9 @@
 	var speechList = document.getElementById('sayit-speech-list');
 	var askPanel = document.getElementById('sayit-ask');
 	var askSubmit = document.getElementById('sayit-ask-submit');
-	var askConsent = document.getElementById('sayit-ask-consent');
-	var askStatus = document.getElementById('sayit-ask-status');
+		var askStatus = document.getElementById('sayit-ask-status');
 	var askAnswer = document.getElementById('sayit-ask-answer');
-	if (!input || !results) return;
+	if (!input) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
 	var ASK_STRINGS = {
@@ -187,11 +186,13 @@
 	}
 
 	function showResults() {
+		if (!results) return;
 		results.hidden = false;
 		if (speechList) speechList.style.display = 'none';
 	}
 
 	function hideResults() {
+		if (!results) return;
 		results.hidden = true;
 		results.innerHTML = '';
 		if (speechList) speechList.style.display = '';
@@ -210,7 +211,7 @@
 	}
 
 	function consentAccepted() {
-		return askConsent ? askConsent.checked : false;
+		return true;
 	}
 
 	function updateAskControls() {
@@ -222,7 +223,6 @@
 		askSubmit.textContent = askLoading
 			? askT.submitting
 			: (askCooldownRemaining > 0 ? askT.cooldown(askCooldownRemaining) : askT.submit);
-		if (askConsent) askConsent.disabled = askLoading;
 
 		if (!askPanel) return;
 		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
@@ -436,6 +436,7 @@
 	}
 
 	function doSearch(query) {
+		if (!results) return;
 		if (!query.trim()) {
 			hideResults();
 			return;
@@ -487,7 +488,7 @@
 
 	function runAsk(question) {
 		var query = (question || '').trim();
-		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return Promise.resolve();
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0) return Promise.resolve();
 		if (query.length > 100) {
 			renderAskAnswer('', false, askT.questionTooLong);
 			return Promise.resolve();
@@ -547,7 +548,7 @@
 	}
 
 	function initAsk() {
-		if (!askSubmit || !askAnswer || !window.fetch) return Promise.resolve();
+		if (!askAnswer || !window.fetch) return Promise.resolve();
 
 		var capacityPromise = fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
 			if (!response.ok) throw new Error('capacity unavailable');
@@ -556,21 +557,10 @@
 			if (!data || data.status !== 'available') return;
 			askAvailable = true;
 			if (askPanel) askPanel.hidden = false;
-			askSubmit.hidden = false;
 			updateAskControls();
 		}).catch(function () {
 			askAvailable = false;
 		});
-
-		askSubmit.addEventListener('click', function () {
-			submitSearch(input.value);
-		});
-
-		if (askConsent) {
-			askConsent.addEventListener('change', function () {
-				updateAskControls();
-			});
-		}
 
 		if (askPanel) {
 			var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
@@ -591,20 +581,21 @@
 
 		var onSearchResults = window.location.pathname === '/search/';
 
-		if (askAnswer && askAvailable && consentAccepted() && q.length <= 100 && !askLoading && askCooldownRemaining <= 0) {
+		if (askAnswer && askAvailable && q.length <= 100 && !askLoading && askCooldownRemaining <= 0) {
 			runAiFirstSearch(q, onSearchResults);
 			return;
 		}
 
 		if (askAnswer) {
-			if (askAvailable && !consentAccepted() && q.length <= 100) setAskStatus(askT.consentRequired);
 			if (onSearchResults) return;
 			hideAskAnswer();
 			doSearch(q);
 			return;
 		}
 
-		window.location.assign('/search/?q=' + encodeURIComponent(query));
+		if (!results) return;
+		hideAskAnswer();
+		doSearch(q);
 	}
 
 	function runAiFirstSearch(query, skipRegularResults) {

--- a/sayit-hono.code-workspace
+++ b/sayit-hono.code-workspace
@@ -4,7 +4,7 @@
 			"path": "."
 		},
 		{
-			"path": "../transcript"
+			"path": "../askit-hono"
 		}
 	],
 	"settings": {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,24 +1,33 @@
 <template>
 	<footer class="full-page__row">
 		<div class="full-page__unit" style="display: flex">
-		<div class="row">
-			<div class="columns small-12 large-9" style="padding: 0">
-			<p style="font-size: 1em; font-weight: bold; display: flex; margin-inline-end: auto;" id="cc">
-				<span lang="zh">本站由 唐鳳 與 唐宗浩 共同維運，除另有標示外，內容以創用 CC0 授權條款釋出</span>
-				<span lang="en">This site is co-maintained by Audrey Tang and Bestian Tang. Unless otherwise indicated, the content is released under the terms of the Creative Commons CC0 license.</span>
-			</p>
+			<div class="row">
+				<div class="columns small-12 large-9" style="padding: 0">
+					<p style="font-size: 1em; font-weight: bold; display: flex; margin-inline-end: auto;" id="cc">
+						<span lang="zh">本站由 唐鳳 與 唐宗浩 共同維運，除另有標示外，內容以創用 CC0 授權條款釋出</span>
+						<span lang="en">This site is co-maintained by Audrey Tang and Bestian Tang. Unless otherwise indicated, the content is released under the terms of the Creative Commons CC0 license.</span>
+					</p>
+					<p class="sayit-footer-ask-notice" style="font-size: 0.95em; font-weight: normal; margin-top: 0.5em;">
+						<span lang="zh">在搜尋框提問即表示您同意 <a href="/privacy">隱私權政策</a> 與 <a href="/terms">使用條款</a>。</span>
+						<span lang="en">By asking a question in the search box, you agree to the <a href="/privacy">Privacy Policy</a> and <a href="/terms">Terms of Use</a>.</span>
+					</p>
+				</div>
+				<div class="columns small-12 large-3" style="padding: 0">
+					<p style="font-size: 1em; font-weight: bold; display: flex; justify-content: end; flex-wrap: wrap; gap: 0.5rem 1rem">
+						<a href="/terms"><span lang="zh">使用條款</span><span lang="en">Terms of Use</span></a>
+						<a href="/privacy"><span lang="zh">隱私權政策</span><span lang="en">Privacy Policy</span></a>
+					</p>
+				</div>
 			</div>
-			<div class="columns small-12 large-3" style="padding: 0">
-			<p style="font-size: 1em; font-weight: bold; display: flex; justify-content: end">
-				<a id="tos"></a>
-				<a id="privacy" style="margin-left: 1rem"></a>
-			</p>
-			</div>
-		</div>
 		</div>
 	</footer>
 </template>
 
-<style scoped>
-</style>
+<script setup lang="ts">
+</script>
 
+<style scoped>
+.sayit-footer-ask-notice a {
+	text-decoration: underline;
+}
+</style>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -155,6 +155,7 @@
 	-webkit-appearance: none;
 }
 
+
 .sayit-search__shortcut {
 	position: absolute;
 	right: 0.8em;
@@ -174,6 +175,10 @@
 	border-radius: 4px;
 	pointer-events: none;
 	transition: opacity 0.25s ease;
+}
+
+.full-page__row.navbar .sayit-search__shortcut {
+	top: 50% !important;
 }
 
 @media (hover: none) {

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -73,6 +73,13 @@
 	align-items: center;
 }
 
+.navbar__right > .sayit-search,
+.navbar__right > .sayit-lang-switch,
+.navbar__right > #sayit-site-lang-toggle,
+.navbar__right > .sayit-share-button {
+	align-self: center;
+}
+
 .navbar__right .sayit-search__input,
 .navbar__right .sayit-search__submit,
 .navbar__right .sayit-lang-switch,
@@ -81,6 +88,16 @@
 	margin: 0;
 	min-height: 2.375rem;
 	height: 2.375rem;
+}
+
+.navbar__right .sayit-lang-switch,
+.navbar__right #sayit-site-lang-toggle,
+.navbar__right .sayit-share-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0 0.95em;
+	line-height: 1.2;
 }
 
 .navbar__right .sayit-search__submit {
@@ -374,7 +391,7 @@ button.sayit-search__more:active {
 	align-items: center;
 	justify-content: center;
 	box-sizing: border-box;
-	margin-top: 5px;
+	margin: 0;
 	padding: 0.45em 0.95em;
 	font-family: 'Noto Sans TC', sans-serif;
 	font-size: 0.9em;
@@ -446,4 +463,10 @@ button.sayit-search__more:active {
 		font-size: 16px;
 	}
 }
+
+.navbar .navbar__right button,
+.navbar .navbar__right input.sayit-search__input {
+	margin: 0 !important;
+}
+
 </style>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -68,6 +68,34 @@
 	align-items: center;
 }
 
+.navbar__right .sayit-search {
+	display: flex;
+	align-items: center;
+}
+
+.navbar__right .sayit-search__input,
+.navbar__right .sayit-search__submit,
+.navbar__right .sayit-lang-switch,
+.navbar__right .sayit-share-button {
+	box-sizing: border-box;
+	margin: 0;
+	min-height: 2.375rem;
+	height: 2.375rem;
+}
+
+.navbar__right .sayit-search__submit {
+	width: 2.375rem;
+	padding: 0;
+	flex-shrink: 0;
+}
+
+.navbar__right .sayit-search__input {
+	padding-top: 0;
+	padding-bottom: 0;
+	line-height: 1.35;
+}
+
+
 @media (max-width: 580px) {
 	.sayit-search {
 		width: 100%;

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -53,13 +53,19 @@
 	align-items: center;
 	justify-content: flex-end;
 	flex-wrap: wrap;
-	gap: 0.6rem;
+	gap: 0.5rem;
 }
 
 /* Search widget styles (shared across all pages with search) */
 .sayit-search {
-	width: 220px;
+	flex: 1 1 12rem;
+	min-width: 10rem;
+	max-width: 20rem;
 	margin: 0;
+}
+
+.navbar__right .sayit-search__row {
+	align-items: center;
 }
 
 @media (max-width: 580px) {

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -16,6 +16,15 @@
 					<slot />
 					<button
 						type="button"
+						id="sayit-site-lang-toggle"
+						class="sayit-lang-switch sayit-site-lang-toggle"
+						aria-label="Switch interface language"
+					>
+						<span lang="zh">English</span>
+						<span lang="en">華文</span>
+					</button>
+					<button
+						type="button"
 						class="sayit-share-button"
 						data-sayit-share
 						aria-controls="sayit-share-feedback"

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -158,7 +158,7 @@
 .sayit-search__shortcut {
 	position: absolute;
 	right: 0.8em;
-	top: 50%;
+	top: 38%;
 	transform: translateY(-50%);
 	display: inline-flex;
 	align-items: center;

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -16,15 +16,6 @@
 					<slot />
 					<button
 						type="button"
-						id="sayit-site-lang-toggle"
-						class="sayit-lang-switch sayit-site-lang-toggle"
-						aria-label="Switch interface language"
-					>
-						<span lang="zh">English</span>
-						<span lang="en">華文</span>
-					</button>
-					<button
-						type="button"
 						class="sayit-share-button"
 						data-sayit-share
 						aria-controls="sayit-share-feedback"

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import SingleSpeakerView, { styles as SingleSpeakerViewStyles } from './.generat
 import SearchResultView, { styles as SearchResultViewStyles } from './.generated/views/SearchResultView';
 import SpeechesView, { styles as SpeechesViewStyles } from './.generated/views/SpeechesView';
 import SpeakersView, { styles as SpeakersViewStyles } from './.generated/views/SpeakersView';
+import LegalPrivacyView, { styles as LegalPrivacyViewStyles } from './.generated/views/LegalPrivacyView';
+import LegalTermsView, { styles as LegalTermsViewStyles } from './.generated/views/LegalTermsView';
 import Navbar, { styles as NavbarStyles } from './.generated/components/Navbar';
 import Footer, { styles as FooterStyles } from './.generated/components/Footer';
 import { renderHtml } from './ssr/render';
@@ -36,7 +38,9 @@ import {
 	headForSpeeches,
 	headForSearch,
 	headForSpeakers,
-	headForHome
+	headForHome,
+	headForPrivacy,
+	headForTerms
 } from './ssr/heads';
 import { buildPaginationPages } from './utils/pagination';
 import { normalizeSections } from './utils/sectionUtils';
@@ -90,6 +94,8 @@ const excludedPaths = [
 	'rss.xml',
 	'feed.xml',
 	'search',
+	'privacy',
+	'terms',
 	'favicon.ico',
 	'robots.txt',
 	'static',
@@ -969,6 +975,31 @@ app.post('/api/cleanup_old_cache', async (c) => {
 	return c.json({ deleted, more: false });
 });
 
+
+async function renderPrivacyPage(c: any) {
+	const styles = [LegalPrivacyViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n');
+	const head = headForPrivacy();
+	const html = await renderHtml(LegalPrivacyView, {
+		head,
+		styles,
+		components: { Navbar, Footer },
+		props: {}
+	});
+	return withCacheHeaders(c.html(html));
+}
+
+async function renderTermsPage(c: any) {
+	const styles = [LegalTermsViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n');
+	const head = headForTerms();
+	const html = await renderHtml(LegalTermsView, {
+		head,
+		styles,
+		components: { Navbar, Footer },
+		props: {}
+	});
+	return withCacheHeaders(c.html(html));
+}
+
 async function renderHomePage(c: any) {
 	const styles = [HomeViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n');
 	const head = headForHome();
@@ -1048,6 +1079,8 @@ async function renderSpeakersPage(c: any) {
 
 // /speeches → /speeches/, /speakers → /speakers/, /index.html → / are all redirected
 // by the canonical-URL middleware before these handlers run.
+app.get('/privacy', (c) => renderPrivacyPage(c));
+app.get('/terms', (c) => renderTermsPage(c));
 app.get('/speeches/', (c) => renderSpeechesPage(c));
 app.get('/speakers/', (c) => renderSpeakersPage(c));
 app.get('/', (c) => renderHomePage(c));

--- a/src/ssr/heads.ts
+++ b/src/ssr/heads.ts
@@ -49,6 +49,20 @@ export function headForHome(): HeadSpec {
 	return { title: ' Home :: SayIt ', meta: [og(baseOgTitle), ogDescription(baseOgDescription), ...defaultImageMeta()] };
 }
 
+export function headForPrivacy(): HeadSpec {
+	return {
+		title: ' Privacy Policy :: SayIt ',
+		meta: [og('Privacy Policy'), ogDescription('Privacy policy for AI questions on SayIt.'), ...defaultImageMeta()]
+	};
+}
+
+export function headForTerms(): HeadSpec {
+	return {
+		title: ' Terms of Use :: SayIt ',
+		meta: [og('Terms of Use'), ogDescription('Terms of use for AI questions on SayIt.'), ...defaultImageMeta()]
+	};
+}
+
 export function headForSpeakers(): HeadSpec {
 	return { title: ' All Speakers :: SayIt ', meta: [og(baseOgTitle), ogDescription(baseOgDescription), ...defaultImageMeta()] };
 }

--- a/src/ssr/render.ts
+++ b/src/ssr/render.ts
@@ -765,6 +765,24 @@ const THEME_STYLES = `<style>
     line-height: 1.6;
   }
   .sayit-ask-overlay .homepage-ask-answer { max-width: none; margin-top: 0.85rem; }
+  .homepage-ask-answer .homepage-ask-answer__toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin: 0 0 0.65rem;
+  }
+  .homepage-ask-answer .homepage-ask-answer__copy {
+    border: 1px solid rgba(199, 194, 186, 0.75);
+    border-radius: 999px;
+    background: #fffaf4;
+    color: #4a433c;
+    font: inherit;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    padding: 0.35rem 0.85rem;
+    cursor: pointer;
+  }
+  .homepage-ask-answer .homepage-ask-answer__copy:hover,
+  .homepage-ask-answer .homepage-ask-answer__copy:focus { background: #fdece8; outline: none; }
   .homepage-ask-answer[hidden] { display: none; }
   .homepage-ask-answer .homepage-ask-answer__status,
   .homepage-ask-answer .homepage-ask-answer__body,

--- a/src/ssr/render.ts
+++ b/src/ssr/render.ts
@@ -836,13 +836,29 @@ const THEME_STYLES = `<style>
     min-height: 2.375rem;
   }
   .navbar__right .sayit-lang-switch,
-  .navbar__right #sayit-site-lang-toggle {
+  .navbar__right #sayit-site-lang-toggle,
+  .navbar__right .sayit-share-button {
+    margin: 0 !important;
+    align-self: center;
     height: 2.375rem;
     min-height: 2.375rem;
-    margin: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    line-height: 1.35;
+    padding: 0 0.95em !important;
+    line-height: 1.2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .navbar__right .sayit-search__input,
+  .navbar__right .sayit-search__submit {
+    margin: 0 !important;
+    align-self: center;
+  }
+  .navbar .navbar__right button,
+  .navbar .navbar__right input[type="search"] {
+    margin: 0 !important;
+  }
+  .navbar .navbar__right .sayit-search__input-wrap {
+    margin: 0 !important;
   }
   .sayit-site-lang-toggle { cursor: pointer; font: inherit; }
   @media (prefers-color-scheme: dark) {

--- a/src/ssr/render.ts
+++ b/src/ssr/render.ts
@@ -823,12 +823,28 @@ const THEME_STYLES = `<style>
     border-radius: 8px;
   }
   .navbar .sayit-search__input {
+    height: 2.375rem;
     min-height: 2.375rem;
     box-sizing: border-box;
-    padding-top: 0.4em;
-    padding-bottom: 0.4em;
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 1.35;
   }
-  .sayit-site-lang-toggle { cursor: pointer; font: inherit; margin: 0; }
+  .navbar .sayit-search__submit {
+    height: 2.375rem;
+    width: 2.375rem;
+    min-height: 2.375rem;
+  }
+  .navbar__right .sayit-lang-switch,
+  .navbar__right #sayit-site-lang-toggle {
+    height: 2.375rem;
+    min-height: 2.375rem;
+    margin: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 1.35;
+  }
+  .sayit-site-lang-toggle { cursor: pointer; font: inherit; }
   @media (prefers-color-scheme: dark) {
     .sayit-ask-overlay .homepage-ask, .homepage-ask-answer {
       border-color: var(--sayit-border, rgba(164, 184, 204, 0.14));

--- a/src/ssr/render.ts
+++ b/src/ssr/render.ts
@@ -1044,14 +1044,31 @@ function wrapHtml(appHtml: string, { title, styles, head, scripts }: RenderOptio
       var hasTouch = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
       root.classList.remove('no-touch');
       root.classList.add(hasTouch ? 'touch' : 'no-touch');
-      var zh = /^zh\\b/i.test(navigator.language);
+      var stored = null;
+      try { stored = localStorage.getItem('sayit-ui-lang'); } catch (e) {}
+      var zh = stored === 'zh' || stored === 'en' ? stored === 'zh' : /^zh\b/i.test(navigator.language || '');
+      root.classList.remove('lang-zh', 'lang-en');
       root.classList.add(zh ? 'lang-zh' : 'lang-en');
-      if (zh) document.addEventListener('DOMContentLoaded', function() {
-        var map = {'Search': '搜尋', "Search this person's speeches": '搜尋此人的發言'};
+      function applyZhPlaceholders() {
+        var map = {'Search': '搜尋', "Search this person's speeches": '搜尋此人的發言', 'Search speeches…': '搜尋對話內容…', 'Search speeches': '搜尋對話'};
         document.querySelectorAll('[placeholder]').forEach(function(el) {
           var zh_text = map[el.getAttribute('placeholder')];
           if (zh_text) el.setAttribute('placeholder', zh_text);
         });
+      }
+      if (zh) {
+        if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', applyZhPlaceholders);
+        else applyZhPlaceholders();
+      }
+      document.addEventListener('click', function(e) {
+        var btn = e.target && e.target.closest ? e.target.closest('#sayit-site-lang-toggle') : null;
+        if (!btn) return;
+        var nextZh = !root.classList.contains('lang-zh');
+        root.classList.remove('lang-zh', 'lang-en');
+        root.classList.add(nextZh ? 'lang-zh' : 'lang-en');
+        try { localStorage.setItem('sayit-ui-lang', nextZh ? 'zh' : 'en'); } catch (err) {}
+        window.dispatchEvent(new CustomEvent('sayit-lang-change', { detail: { zh: nextZh } }));
+        if (nextZh) applyZhPlaceholders();
       });
     })();
   </script>

--- a/src/ssr/render.ts
+++ b/src/ssr/render.ts
@@ -704,6 +704,128 @@ const THEME_STYLES = `<style>
      永遠不命中、連結變成永遠顯示。
      純觸控裝置 (hover: hover) 為 false，這段不適用，連結維持永遠顯示
      —— 對沒有 hover 的裝置才合理。 */
+  .sayit-ask-overlay {
+    max-width: 71.25em;
+    margin: 0.75rem auto 0;
+    padding: 0 0.75em;
+    box-sizing: border-box;
+  }
+  .homepage-ask {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    max-width: 680px;
+    margin-top: 1rem;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+  }
+  .sayit-ask-overlay .homepage-ask {
+    max-width: none;
+    margin-top: 0;
+    align-items: stretch;
+    text-align: left;
+    padding: 1rem 1.15rem;
+    border: 1px solid rgba(199, 194, 186, 0.95);
+    border-radius: 14px;
+    background: linear-gradient(180deg, #ffffff 0%, #f7f2ec 100%);
+    box-shadow: 0 10px 26px rgba(73, 54, 40, 0.07);
+    box-sizing: border-box;
+  }
+  .homepage-ask[hidden] { display: none; }
+  .homepage-ask__intro, .homepage-ask__status { margin: 0; color: #6b6357; }
+  .homepage-ask__submit {
+    border: 1px solid rgba(201, 86, 75, 0.28);
+    border-radius: 999px;
+    background: #fffaf4;
+    color: #a8443b;
+    font: inherit;
+    cursor: pointer;
+    flex: 0 0 auto;
+    padding: 0.55rem 1.3rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  .homepage-ask__submit[hidden] { display: none; }
+  .homepage-ask__submit:hover, .homepage-ask__submit:focus { background: #fdece8; outline: none; }
+  .homepage-ask__submit:disabled { cursor: not-allowed; opacity: 0.62; }
+  .homepage-ask-answer {
+    width: 100%;
+    max-width: 760px;
+    margin: 1.5rem auto 0;
+    padding: 1.25rem 1.35rem;
+    border: 1px solid rgba(199, 194, 186, 0.95);
+    border-radius: 16px;
+    background: linear-gradient(180deg, #ffffff 0%, #f7f2ec 100%);
+    box-shadow: 0 12px 30px rgba(73, 54, 40, 0.08);
+    box-sizing: border-box;
+    line-height: 1.6;
+  }
+  .sayit-ask-overlay .homepage-ask-answer { max-width: none; margin-top: 0.85rem; }
+  .homepage-ask-answer[hidden] { display: none; }
+  .homepage-ask-answer .homepage-ask-answer__status,
+  .homepage-ask-answer .homepage-ask-answer__body,
+  .homepage-ask-answer .homepage-ask-answer__error { margin: 0; line-height: 1.6; }
+  .homepage-ask-answer .homepage-ask-answer__body { white-space: pre-wrap; word-break: break-word; }
+  .homepage-ask-answer .homepage-ask-answer__body sup.cite { line-height: 1; vertical-align: super; }
+  .homepage-ask-answer .homepage-ask-answer__error { color: #a8443b; }
+  .homepage-ask-answer .homepage-ask-answer__cursor {
+    display: inline-block;
+    margin-left: 0.1em;
+    animation: ask-cursor-blink 1s steps(1) infinite;
+  }
+  .homepage-ask-answer .homepage-ask-answer__sources {
+    margin-top: 1.35rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid rgba(199, 194, 186, 0.55);
+  }
+  .homepage-ask-answer .homepage-ask-answer__sources h3 { margin: 0 0 0.65rem; font-size: 1rem; line-height: 1.6; }
+  .homepage-ask-answer .homepage-ask-answer__sources ol { margin: 0; padding: 0; list-style-position: inside; line-height: 1.6; }
+  .homepage-ask-answer .homepage-ask-answer__sources li { margin: 0.45rem 0; }
+  @keyframes ask-cursor-blink { 50% { opacity: 0; } }
+  .sayit-search__row { display: flex; align-items: stretch; gap: 0.45rem; width: 100%; }
+  .sayit-search__row .sayit-search__input-wrap { flex: 1 1 auto; min-width: 0; }
+  .sayit-search__submit {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    min-height: 2.5rem;
+    padding: 0;
+    color: #a8443b;
+    background: #fffaf4;
+    border: 1.5px solid rgba(201, 86, 75, 0.35);
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .sayit-search__submit[hidden] { display: none; }
+  .sayit-search__submit:hover:not(:disabled), .sayit-search__submit:focus-visible:not(:disabled) {
+    background: #fdece8; border-color: #c9564b; outline: none;
+  }
+  .sayit-search__submit:disabled { opacity: 0.5; cursor: not-allowed; }
+  .sayit-search__submit svg { display: block; width: 1.15rem; height: 1.15rem; }
+  .sayit-search--homepage { flex: 1 1 auto; min-width: 0; width: auto; max-width: none; }
+  .sayit-search--homepage .sayit-search__input {
+    font-size: 1.1em; padding: 0.6em 1.1em; padding-right: 2.8em; border-radius: 8px;
+  }
+  .sayit-site-lang-toggle { cursor: pointer; font: inherit; }
+  @media (prefers-color-scheme: dark) {
+    .sayit-ask-overlay .homepage-ask, .homepage-ask-answer {
+      border-color: var(--sayit-border, rgba(164, 184, 204, 0.14));
+      background: linear-gradient(180deg, rgba(20, 29, 42, 0.96), rgba(13, 20, 31, 0.9));
+      color: var(--sayit-text, #ecf2f8);
+    }
+    .homepage-ask__intro, .homepage-ask__status { color: var(--sayit-text-muted, #b8c4d1); }
+    .homepage-ask__submit, .sayit-search__submit {
+      border-color: rgba(127, 214, 176, 0.36);
+      background: rgba(18, 26, 37, 0.92);
+      color: var(--sayit-link-hover, #ffd0c7);
+    }
+  }
+
   @media (hover: hover) {
     .speech__links { display: none !important; }
 

--- a/src/ssr/render.ts
+++ b/src/ssr/render.ts
@@ -88,7 +88,8 @@ const THEME_STYLES = `<style>
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
-    margin-top: -13px;
+    margin: 0;
+    min-height: 2.375rem;
     padding: 0.45em 0.95em;
     font-family: 'Noto Sans TC', sans-serif;
     font-size: 0.9em;
@@ -785,20 +786,22 @@ const THEME_STYLES = `<style>
   .homepage-ask-answer .homepage-ask-answer__sources ol { margin: 0; padding: 0; list-style-position: inside; line-height: 1.6; }
   .homepage-ask-answer .homepage-ask-answer__sources li { margin: 0.45rem 0; }
   @keyframes ask-cursor-blink { 50% { opacity: 0; } }
-  .sayit-search__row { display: flex; align-items: stretch; gap: 0.45rem; width: 100%; }
+  .sayit-search__row { display: flex; align-items: center; gap: 0.4rem; width: 100%; }
   .sayit-search__row .sayit-search__input-wrap { flex: 1 1 auto; min-width: 0; }
   .sayit-search__submit {
     flex: 0 0 auto;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.5rem;
-    min-height: 2.5rem;
+    box-sizing: border-box;
+    width: 2.375rem;
+    height: 2.375rem;
+    min-height: 2.375rem;
     padding: 0;
     color: #a8443b;
     background: #fffaf4;
     border: 1.5px solid rgba(201, 86, 75, 0.35);
-    border-radius: 8px;
+    border-radius: 6px;
     cursor: pointer;
   }
   .sayit-search__submit[hidden] { display: none; }
@@ -809,9 +812,23 @@ const THEME_STYLES = `<style>
   .sayit-search__submit svg { display: block; width: 1.15rem; height: 1.15rem; }
   .sayit-search--homepage { flex: 1 1 auto; min-width: 0; width: auto; max-width: none; }
   .sayit-search--homepage .sayit-search__input {
-    font-size: 1.1em; padding: 0.6em 1.1em; padding-right: 2.8em; border-radius: 8px;
+    font-size: 1.1em; padding: 0.55em 1.1em; padding-right: 2.8em; border-radius: 8px;
+    min-height: 2.75rem;
+    box-sizing: border-box;
   }
-  .sayit-site-lang-toggle { cursor: pointer; font: inherit; }
+  .sayit-search--homepage .sayit-search__submit {
+    width: 2.75rem;
+    height: 2.75rem;
+    min-height: 2.75rem;
+    border-radius: 8px;
+  }
+  .navbar .sayit-search__input {
+    min-height: 2.375rem;
+    box-sizing: border-box;
+    padding-top: 0.4em;
+    padding-bottom: 0.4em;
+  }
+  .sayit-site-lang-toggle { cursor: pointer; font: inherit; margin: 0; }
   @media (prefers-color-scheme: dark) {
     .sayit-ask-overlay .homepage-ask, .homepage-ask-answer {
       border-color: var(--sayit-border, rgba(164, 184, 204, 0.14));

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -7,22 +7,6 @@
 				<div class="page-content__row">
 					<div class="homepage-search">
 						<h2><span lang="zh">搜尋對話與發言</span><span lang="en">Search speeches and statements</span></h2>
-						<div class="homepage-search__row">
-							<div id="sayit-search" class="sayit-search sayit-search--homepage" role="search">
-								<div class="sayit-search__input-wrap">
-									<input
-										id="sayit-search-input"
-										type="search"
-										class="sayit-search__input"
-										autocomplete="off"
-										spellcheck="false"
-										aria-label="Search speeches"
-									>
-									<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
-								</div>
-							</div>
-							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
-						</div>
 						<div id="sayit-ask" class="homepage-ask" hidden>
 							<p class="homepage-ask__intro">
 								<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
@@ -42,6 +26,22 @@
 								</span>
 							</label>
 							<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+						</div>
+						<div class="homepage-search__row">
+							<div id="sayit-search" class="sayit-search sayit-search--homepage" role="search">
+								<div class="sayit-search__input-wrap">
+									<input
+										id="sayit-search-input"
+										type="search"
+										class="sayit-search__input"
+										autocomplete="off"
+										spellcheck="false"
+										aria-label="Search speeches"
+									>
+									<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								</div>
+							</div>
+							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 						</div>
 					</div>
 				</div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -8,10 +8,6 @@
 					<div class="homepage-search">
 						<h2><span lang="zh">搜尋對話與發言</span><span lang="en">Search speeches and statements</span></h2>
 						<div id="sayit-ask" class="homepage-ask" hidden>
-							<p class="homepage-ask__intro">
-								<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-								<span lang="en">Or ask a question and let AI search the transcripts:</span>
-							</p>
 							<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 						</div>
 						<div class="homepage-search__row">
@@ -34,12 +30,11 @@
 								</div>
 							</div>
 							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+						</div>
 					</div>
 				</div>
-				<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden>
-				</div>
-				<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden>
-				</div>
+				<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+				<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 			</div>
 			<div class="homepage-stats" id="sayit-stats">
 			<div class="full-page__row">
@@ -66,7 +61,7 @@
 
 .homepage-search__row {
 	display: flex;
-	align-items: stretch;
+	align-items: center;
 	gap: 0.65rem;
 	width: 100%;
 	max-width: 680px;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -20,9 +20,22 @@
 								<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
 							</div>
 						</div>
+						<div id="sayit-ask" class="homepage-ask" hidden>
+							<p class="homepage-ask__intro">或直接提問，讓 AI 從逐字稿中找出回答：</p>
+							<div class="homepage-ask__samples" aria-label="範例問句">
+								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="什麼是仁工智慧？">什麼是仁工智慧？</button>
+								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="什麼是數位民主？">什麼是數位民主？</button>
+								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="如何看待開放政府？">如何看待開放政府？</button>
+								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="唐鳳對 AI 的看法？">唐鳳對 AI 的看法？</button>
+							</div>
+							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit">💬 提問</button>
+							<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+						</div>
 					</div>
 				</div>
 				<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden>
+				</div>
+				<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden>
 				</div>
 			</div>
 			</div>
@@ -60,6 +73,183 @@
 	padding: 0.6em 1.1em;
 	padding-right: 2.8em;
 	border-radius: 8px;
+}
+
+.homepage-ask {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.75rem;
+	width: 100%;
+	max-width: 680px;
+	margin-top: 1rem;
+	text-align: center;
+}
+
+.homepage-ask[hidden] {
+	display: none;
+}
+
+.homepage-ask__intro,
+.homepage-ask__status {
+	margin: 0;
+	color: #6b6357;
+}
+
+.homepage-ask__samples {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 0.5rem;
+}
+
+.homepage-ask__sample,
+.homepage-ask__submit {
+	border: 1px solid rgba(201, 86, 75, 0.28);
+	border-radius: 999px;
+	background: #fffaf4;
+	color: #a8443b;
+	font: inherit;
+	cursor: pointer;
+}
+
+.homepage-ask__sample {
+	padding: 0.4rem 0.8rem;
+}
+
+.homepage-ask__submit {
+	padding: 0.55rem 1.3rem;
+	font-weight: 700;
+}
+
+.homepage-ask__sample:hover,
+.homepage-ask__sample:focus,
+.homepage-ask__submit:hover,
+.homepage-ask__submit:focus {
+	background: #fdece8;
+	outline: none;
+}
+
+.homepage-ask__sample:disabled,
+.homepage-ask__submit:disabled {
+	cursor: not-allowed;
+	opacity: 0.62;
+}
+
+.homepage-ask-answer {
+	width: 100%;
+	max-width: 760px;
+	margin: 1.5rem auto 0;
+	padding: 1.25rem 1.35rem;
+	border: 1px solid rgba(199, 194, 186, 0.95);
+	border-radius: 16px;
+	background: linear-gradient(180deg, #ffffff 0%, #f7f2ec 100%);
+	box-shadow: 0 12px 30px rgba(73, 54, 40, 0.08);
+	box-sizing: border-box;
+	line-height: 1.6;
+}
+
+.homepage-ask-answer[hidden] {
+	display: none;
+}
+
+/* 子元素由 JS 動態插入，需用後代選擇器才能套到 scoped 樣式 */
+.homepage-ask-answer :is(.homepage-ask-answer__status, .homepage-ask-answer__body, .homepage-ask-answer__error) {
+	margin: 0;
+	line-height: 1.6;
+}
+
+.homepage-ask-answer .homepage-ask-answer__body {
+	white-space: pre-wrap;
+}
+
+.homepage-ask-answer .homepage-ask-answer__body strong {
+	display: inline-block;
+	margin-top: 0.85em;
+}
+
+.homepage-ask-answer .homepage-ask-answer__body strong:first-child {
+	margin-top: 0;
+}
+
+.homepage-ask-answer .homepage-ask-answer__body sup.cite {
+	line-height: 1;
+	vertical-align: super;
+}
+
+.homepage-ask-answer .homepage-ask-answer__error {
+	color: #a8443b;
+}
+
+.homepage-ask-answer .homepage-ask-answer__cursor {
+	display: inline-block;
+	margin-left: 0.1em;
+	animation: ask-cursor-blink 1s steps(1) infinite;
+}
+
+.homepage-ask-answer .homepage-ask-answer__sources {
+	margin-top: 1.35rem;
+	padding-top: 0.85rem;
+	border-top: 1px solid rgba(199, 194, 186, 0.55);
+}
+
+.homepage-ask-answer .homepage-ask-answer__sources h3 {
+	margin: 0 0 0.65rem;
+	font-size: 1rem;
+	line-height: 1.6;
+}
+
+.homepage-ask-answer .homepage-ask-answer__sources ol {
+	margin: 0;
+	margin-left: 1.6rem;
+	padding-left: 1.6rem;
+	line-height: 1.6;
+}
+
+.homepage-ask-answer .homepage-ask-answer__sources li {
+	margin: 0.45rem 0;
+}
+
+.homepage-ask-answer .homepage-ask-answer__sources li:first-child {
+	margin-top: 0;
+}
+
+.homepage-ask-answer .homepage-ask-answer__sources li:last-child {
+	margin-bottom: 0;
+}
+
+@keyframes ask-cursor-blink {
+	50% {
+		opacity: 0;
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	.homepage-ask__intro,
+	.homepage-ask__status {
+		color: var(--sayit-text-muted, #b8c4d1);
+	}
+
+	.homepage-ask__sample,
+	.homepage-ask__submit {
+		border-color: rgba(127, 214, 176, 0.36);
+		background: rgba(18, 26, 37, 0.92);
+		color: var(--sayit-link-hover, #ffd0c7);
+	}
+
+	.homepage-ask__sample:hover,
+	.homepage-ask__sample:focus,
+	.homepage-ask__submit:hover,
+	.homepage-ask__submit:focus {
+		background: rgba(24, 35, 49, 0.98);
+	}
+
+	.homepage-ask-answer {
+		border-color: var(--sayit-border, rgba(164, 184, 204, 0.14));
+		background: linear-gradient(180deg, rgba(20, 29, 42, 0.96), rgba(13, 20, 31, 0.9));
+		color: var(--sayit-text, #ecf2f8);
+		box-shadow: 0 14px 28px rgba(0, 0, 0, 0.18);
+	}
 }
 
 .homepage-stats .full-page__unit {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -16,27 +16,30 @@
 						</div>
 						<div class="homepage-search__row">
 							<div id="sayit-search" class="sayit-search sayit-search--homepage" role="search">
-								<div class="sayit-search__input-wrap">
-									<input
-										id="sayit-search-input"
-										type="search"
-										class="sayit-search__input"
-										autocomplete="off"
-										spellcheck="false"
-										aria-label="Search speeches"
-									>
-									<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+									<div class="sayit-search__input-wrap">
+										<input
+											id="sayit-search-input"
+											type="search"
+											class="sayit-search__input"
+											autocomplete="off"
+											spellcheck="false"
+											aria-label="Search speeches"
+										>
+										<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+									</div>
+									<button type="button" class="sayit-search__submit" aria-label="Search">
+										<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+									</button>
 								</div>
 							</div>
-							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
-						</div>
+							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
 					</div>
 				</div>
 				<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden>
 				</div>
 				<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden>
 				</div>
-			</div>
 			</div>
 			<div class="homepage-stats" id="sayit-stats">
 			<div class="full-page__row">
@@ -45,7 +48,6 @@
 				<a href="/speakers"><strong id="sayit-stat-speakers"></strong></a> <span lang="zh">位講者</span><span lang="en">speakers</span>;
 				<a href="/speeches"><strong id="sayit-stat-sections"></strong></a> <span lang="zh">場會議</span><span lang="en">sections</span>
 				</div>
-			</div>
 			</div>
 		</div>
 		<Footer />
@@ -70,261 +72,21 @@
 	max-width: 680px;
 }
 
-.sayit-search--homepage {
-	flex: 1 1 auto;
-	min-width: 0;
-	width: auto;
-	max-width: none;
-}
-
-.sayit-search--homepage .sayit-search__input {
-	font-size: 1.1em;
-	padding: 0.6em 1.1em;
-	padding-right: 2.8em;
-	border-radius: 8px;
-}
-
-.homepage-ask {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 0.75rem;
-	width: 100%;
-	max-width: 680px;
-	margin-top: 1rem;
-	text-align: center;
-}
-
-.homepage-ask[hidden] {
-	display: none;
-}
-
-.homepage-ask__intro,
-.homepage-ask__status {
-	margin: 0;
-	color: #6b6357;
-}
-
-.homepage-ask__consent {
-	display: flex;
-	align-items: flex-start;
-	gap: 0.5rem;
-	max-width: 680px;
-	margin: 0;
-	text-align: left;
-	font-size: 0.95rem;
-	color: #6b6357;
-	cursor: pointer;
-}
-
-.homepage-ask__consent input {
-	margin-top: 1px;
-	flex: 0 0 auto;
-	accent-color: #c9564b;
-}
-
-.homepage-ask__consent a {
-	color: #c9564b;
-	text-underline-offset: 0.18em;
-}
-
-.homepage-ask__consent a:hover {
-	color: #a8443b;
-}
-
-.homepage-ask__samples {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
-	gap: 0.5rem;
-}
-
-.homepage-ask__sample,
-.homepage-ask__submit {
-	border: 1px solid rgba(201, 86, 75, 0.28);
-	border-radius: 999px;
-	background: #fffaf4;
-	color: #a8443b;
-	font: inherit;
-	cursor: pointer;
-}
-
-.homepage-ask__sample {
-	padding: 0.4rem 0.8rem;
-}
-
-.homepage-ask__submit {
-	flex: 0 0 auto;
-	align-self: stretch;
-	padding: 0.55rem 1.3rem;
-	font-weight: 700;
-	white-space: nowrap;
-}
-
-.homepage-ask__submit[hidden] {
-	display: none;
-}
-
-.homepage-ask__sample:hover,
-.homepage-ask__sample:focus,
-.homepage-ask__submit:hover,
-.homepage-ask__submit:focus {
-	background: #fdece8;
-	outline: none;
-}
-
-.homepage-ask__sample:disabled,
-.homepage-ask__submit:disabled {
-	cursor: not-allowed;
-	opacity: 0.62;
-}
-
-.homepage-ask-answer {
-	width: 100%;
-	max-width: 760px;
-	margin: 1.5rem auto 0;
-	padding: 1.25rem 1.35rem;
-	border: 1px solid rgba(199, 194, 186, 0.95);
-	border-radius: 16px;
-	background: linear-gradient(180deg, #ffffff 0%, #f7f2ec 100%);
-	box-shadow: 0 12px 30px rgba(73, 54, 40, 0.08);
-	box-sizing: border-box;
-	line-height: 1.6;
-}
-
-.homepage-ask-answer[hidden] {
-	display: none;
-}
-
-/* 子元素由 JS 動態插入，需用 :deep() 才能套到 scoped 樣式 */
-.homepage-ask-answer :deep(.homepage-ask-answer__status),
-.homepage-ask-answer :deep(.homepage-ask-answer__body),
-.homepage-ask-answer :deep(.homepage-ask-answer__error) {
-	margin: 0;
-	line-height: 1.6;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__body) {
-	white-space: pre-wrap;
-	word-break: break-word;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__body sup.cite) {
-	line-height: 1;
-	vertical-align: super;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__error) {
-	color: #a8443b;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__cursor) {
-	display: inline-block;
-	margin-left: 0.1em;
-	animation: ask-cursor-blink 1s steps(1) infinite;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__sources) {
-	margin-top: 1.35rem;
-	padding-top: 0.85rem;
-	border-top: 1px solid rgba(199, 194, 186, 0.55);
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__sources h3) {
-	margin: 0 0 0.65rem;
-	padding: 0;
-	font-size: 1rem;
-	line-height: 1.6;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__sources ol) {
-	margin: 0;
-	padding: 0;
-	list-style-position: inside;
-	line-height: 1.6;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__sources li) {
-	margin: 0.45rem 0;
-	padding: 0;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__sources li:first-child) {
-	margin-top: 0;
-}
-
-.homepage-ask-answer :deep(.homepage-ask-answer__sources li:last-child) {
-	margin-bottom: 0;
-}
-
-@keyframes ask-cursor-blink {
-	50% {
-		opacity: 0;
-	}
-}
-
-@media (max-width: 580px) {
-	.homepage-search__row {
-		flex-direction: column;
-	}
-
-	.homepage-ask__submit {
-		width: 100%;
-	}
-}
-
-@media (prefers-color-scheme: dark) {
-	.homepage-ask__intro,
-	.homepage-ask__status,
-	.homepage-ask__consent {
-		color: var(--sayit-text-muted, #b8c4d1);
-	}
-
-	.homepage-ask__consent a {
-		color: var(--sayit-link, #9fc2ff);
-	}
-
-	.homepage-ask__consent a:hover {
-		color: var(--sayit-link-hover, #ffd0c7);
-	}
-
-	.homepage-ask__sample,
-	.homepage-ask__submit {
-		border-color: rgba(127, 214, 176, 0.36);
-		background: rgba(18, 26, 37, 0.92);
-		color: var(--sayit-link-hover, #ffd0c7);
-	}
-
-	.homepage-ask__sample:hover,
-	.homepage-ask__sample:focus,
-	.homepage-ask__submit:hover,
-	.homepage-ask__submit:focus {
-		background: rgba(24, 35, 49, 0.98);
-	}
-
-	.homepage-ask-answer {
-		border-color: var(--sayit-border, rgba(164, 184, 204, 0.14));
-		background: linear-gradient(180deg, rgba(20, 29, 42, 0.96), rgba(13, 20, 31, 0.9));
-		color: var(--sayit-text, #ecf2f8);
-		box-shadow: 0 14px 28px rgba(0, 0, 0, 0.18);
-	}
-}
-
 .homepage-stats .full-page__unit {
 	font-size: 1.15em;
 	color: #6b6357;
 }
 
-.homepage-stats a {
-	text-decoration: none;
-}
+.homepage-stats a { text-decoration: none; }
 
 .homepage-stats strong {
 	font-weight: 700;
 	color: #c9564b;
 }
 
-.homepage-stats a:hover strong {
-	color: #a8443b;
+.homepage-stats a:hover strong { color: #a8443b; }
+
+@media (max-width: 580px) {
+	.homepage-search__row { flex-direction: column; }
 }
 </style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,6 +1,16 @@
 <template>
 	<div class="page">
-		<Navbar />
+		<Navbar>
+			<button
+				type="button"
+				id="sayit-site-lang-toggle"
+				class="sayit-lang-switch sayit-site-lang-toggle"
+				aria-label="Switch interface language"
+			>
+				<span lang="zh">English</span>
+				<span lang="en">華文</span>
+			</button>
+		</Navbar>
 		<div class="full-page">
 			<div class="full-page__row">
 			<div class="full-page__unit">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -7,28 +7,40 @@
 				<div class="page-content__row">
 					<div class="homepage-search">
 						<h2><span lang="zh">搜尋對話與發言</span><span lang="en">Search speeches and statements</span></h2>
-						<div id="sayit-search" class="sayit-search sayit-search--homepage" role="search">
-							<div class="sayit-search__input-wrap">
-								<input
-									id="sayit-search-input"
-									type="search"
-									class="sayit-search__input"
-									autocomplete="off"
-									spellcheck="false"
-									aria-label="Search speeches"
-								>
-								<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+						<div class="homepage-search__row">
+							<div id="sayit-search" class="sayit-search sayit-search--homepage" role="search">
+								<div class="sayit-search__input-wrap">
+									<input
+										id="sayit-search-input"
+										type="search"
+										class="sayit-search__input"
+										autocomplete="off"
+										spellcheck="false"
+										aria-label="Search speeches"
+									>
+									<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								</div>
 							</div>
+							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 						</div>
 						<div id="sayit-ask" class="homepage-ask" hidden>
-							<p class="homepage-ask__intro">或直接提問，讓 AI 從逐字稿中找出回答：</p>
-							<div class="homepage-ask__samples" aria-label="範例問句">
+							<p class="homepage-ask__intro">
+								<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+								<span lang="en">Or ask a question and let AI search the transcripts:</span>
+							</p>
+							<!-- <div class="homepage-ask__samples" aria-label="範例問句">
 								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="什麼是仁工智慧？">什麼是仁工智慧？</button>
 								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="什麼是數位民主？">什麼是數位民主？</button>
 								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="如何看待開放政府？">如何看待開放政府？</button>
 								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="唐鳳對 AI 的看法？">唐鳳對 AI 的看法？</button>
-							</div>
-							<button type="button" id="sayit-ask-submit" class="homepage-ask__submit">💬 提問</button>
+							</div> -->
+							<label class="homepage-ask__consent" id="sayit-ask-consent-label">
+								<input type="checkbox" id="sayit-ask-consent">
+								<span>
+									<span lang="zh">我已閱讀並同意 <a href="https://ask.archive.tw/privacy" target="_blank" rel="noopener noreferrer">隱私權政策</a> 和 <a href="https://ask.archive.tw/terms" target="_blank" rel="noopener noreferrer">使用條款</a></span>
+									<span lang="en">I have read and agree to the <a href="https://ask.archive.tw/en/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and the <a href="https://ask.archive.tw/en/terms" target="_blank" rel="noopener noreferrer">Terms of Use</a></span>
+								</span>
+							</label>
 							<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 						</div>
 					</div>
@@ -63,9 +75,19 @@
 	align-items: center;
 }
 
-.sayit-search--homepage {
+.homepage-search__row {
+	display: flex;
+	align-items: stretch;
+	gap: 0.65rem;
 	width: 100%;
-	max-width: 520px;
+	max-width: 680px;
+}
+
+.sayit-search--homepage {
+	flex: 1 1 auto;
+	min-width: 0;
+	width: auto;
+	max-width: none;
 }
 
 .sayit-search--homepage .sayit-search__input {
@@ -96,6 +118,33 @@
 	color: #6b6357;
 }
 
+.homepage-ask__consent {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+	max-width: 680px;
+	margin: 0;
+	text-align: left;
+	font-size: 0.95rem;
+	color: #6b6357;
+	cursor: pointer;
+}
+
+.homepage-ask__consent input {
+	margin-top: 1px;
+	flex: 0 0 auto;
+	accent-color: #c9564b;
+}
+
+.homepage-ask__consent a {
+	color: #c9564b;
+	text-underline-offset: 0.18em;
+}
+
+.homepage-ask__consent a:hover {
+	color: #a8443b;
+}
+
 .homepage-ask__samples {
 	display: flex;
 	flex-wrap: wrap;
@@ -118,8 +167,15 @@
 }
 
 .homepage-ask__submit {
+	flex: 0 0 auto;
+	align-self: stretch;
 	padding: 0.55rem 1.3rem;
 	font-weight: 700;
+	white-space: nowrap;
+}
+
+.homepage-ask__submit[hidden] {
+	display: none;
 }
 
 .homepage-ask__sample:hover,
@@ -153,68 +209,64 @@
 	display: none;
 }
 
-/* 子元素由 JS 動態插入，需用後代選擇器才能套到 scoped 樣式 */
-.homepage-ask-answer :is(.homepage-ask-answer__status, .homepage-ask-answer__body, .homepage-ask-answer__error) {
+/* 子元素由 JS 動態插入，需用 :deep() 才能套到 scoped 樣式 */
+.homepage-ask-answer :deep(.homepage-ask-answer__status),
+.homepage-ask-answer :deep(.homepage-ask-answer__body),
+.homepage-ask-answer :deep(.homepage-ask-answer__error) {
 	margin: 0;
 	line-height: 1.6;
 }
 
-.homepage-ask-answer .homepage-ask-answer__body {
+.homepage-ask-answer :deep(.homepage-ask-answer__body) {
 	white-space: pre-wrap;
+	word-break: break-word;
 }
 
-.homepage-ask-answer .homepage-ask-answer__body strong {
-	display: inline-block;
-	margin-top: 0.85em;
-}
-
-.homepage-ask-answer .homepage-ask-answer__body strong:first-child {
-	margin-top: 0;
-}
-
-.homepage-ask-answer .homepage-ask-answer__body sup.cite {
+.homepage-ask-answer :deep(.homepage-ask-answer__body sup.cite) {
 	line-height: 1;
 	vertical-align: super;
 }
 
-.homepage-ask-answer .homepage-ask-answer__error {
+.homepage-ask-answer :deep(.homepage-ask-answer__error) {
 	color: #a8443b;
 }
 
-.homepage-ask-answer .homepage-ask-answer__cursor {
+.homepage-ask-answer :deep(.homepage-ask-answer__cursor) {
 	display: inline-block;
 	margin-left: 0.1em;
 	animation: ask-cursor-blink 1s steps(1) infinite;
 }
 
-.homepage-ask-answer .homepage-ask-answer__sources {
+.homepage-ask-answer :deep(.homepage-ask-answer__sources) {
 	margin-top: 1.35rem;
 	padding-top: 0.85rem;
 	border-top: 1px solid rgba(199, 194, 186, 0.55);
 }
 
-.homepage-ask-answer .homepage-ask-answer__sources h3 {
+.homepage-ask-answer :deep(.homepage-ask-answer__sources h3) {
 	margin: 0 0 0.65rem;
+	padding: 0;
 	font-size: 1rem;
 	line-height: 1.6;
 }
 
-.homepage-ask-answer .homepage-ask-answer__sources ol {
+.homepage-ask-answer :deep(.homepage-ask-answer__sources ol) {
 	margin: 0;
-	margin-left: 1.6rem;
-	padding-left: 1.6rem;
+	padding: 0;
+	list-style-position: inside;
 	line-height: 1.6;
 }
 
-.homepage-ask-answer .homepage-ask-answer__sources li {
+.homepage-ask-answer :deep(.homepage-ask-answer__sources li) {
 	margin: 0.45rem 0;
+	padding: 0;
 }
 
-.homepage-ask-answer .homepage-ask-answer__sources li:first-child {
+.homepage-ask-answer :deep(.homepage-ask-answer__sources li:first-child) {
 	margin-top: 0;
 }
 
-.homepage-ask-answer .homepage-ask-answer__sources li:last-child {
+.homepage-ask-answer :deep(.homepage-ask-answer__sources li:last-child) {
 	margin-bottom: 0;
 }
 
@@ -224,10 +276,29 @@
 	}
 }
 
+@media (max-width: 580px) {
+	.homepage-search__row {
+		flex-direction: column;
+	}
+
+	.homepage-ask__submit {
+		width: 100%;
+	}
+}
+
 @media (prefers-color-scheme: dark) {
 	.homepage-ask__intro,
-	.homepage-ask__status {
+	.homepage-ask__status,
+	.homepage-ask__consent {
 		color: var(--sayit-text-muted, #b8c4d1);
+	}
+
+	.homepage-ask__consent a {
+		color: var(--sayit-link, #9fc2ff);
+	}
+
+	.homepage-ask__consent a:hover {
+		color: var(--sayit-link-hover, #ffd0c7);
 	}
 
 	.homepage-ask__sample,

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -12,19 +12,6 @@
 								<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
 								<span lang="en">Or ask a question and let AI search the transcripts:</span>
 							</p>
-							<!-- <div class="homepage-ask__samples" aria-label="範例問句">
-								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="什麼是仁工智慧？">什麼是仁工智慧？</button>
-								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="什麼是數位民主？">什麼是數位民主？</button>
-								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="如何看待開放政府？">如何看待開放政府？</button>
-								<button type="button" class="homepage-ask__sample" data-sayit-ask-question="唐鳳對 AI 的看法？">唐鳳對 AI 的看法？</button>
-							</div> -->
-							<label class="homepage-ask__consent" id="sayit-ask-consent-label">
-								<input type="checkbox" id="sayit-ask-consent">
-								<span>
-									<span lang="zh">我已閱讀並同意 <a href="https://ask.archive.tw/privacy" target="_blank" rel="noopener noreferrer">隱私權政策</a> 和 <a href="https://ask.archive.tw/terms" target="_blank" rel="noopener noreferrer">使用條款</a></span>
-									<span lang="en">I have read and agree to the <a href="https://ask.archive.tw/en/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and the <a href="https://ask.archive.tw/en/terms" target="_blank" rel="noopener noreferrer">Terms of Use</a></span>
-								</span>
-							</label>
 							<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 						</div>
 						<div class="homepage-search__row">

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -45,9 +45,9 @@
 						</div>
 					</div>
 				</div>
-				<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden>
-				</div>
 				<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden>
+				</div>
+				<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden>
 				</div>
 			</div>
 			</div>

--- a/src/views/LegalPrivacyView.vue
+++ b/src/views/LegalPrivacyView.vue
@@ -1,0 +1,77 @@
+<template>
+	<div class="page">
+		<Navbar />
+		<div class="full-page">
+			<div class="full-page__row">
+				<div class="full-page__unit legal-page">
+					<h1><span lang="zh">隱私權政策</span><span lang="en">Privacy Policy</span></h1>
+					<section class="legal-page__section" aria-labelledby="privacy-zh">
+						<h2 id="privacy-zh"><span lang="zh">華語</span></h2>
+						<div lang="zh">
+							<p>我們希望本站 AI 提問功能能成為友善、開放、可持續的公共知識入口，讓更多人安心提問、分享與學習。</p>
+							<p>我們不會販售或交換您的個人資料，也不會為廣告目的替您建立個人檔案。</p>
+							<p>當您在搜尋框提出問題時，服務會收集並保留您提出的問題，用於產生回覆、維護服務品質、偵測濫用與處理資安事件。</p>
+							<p>為了讓服務穩定、對每位使用者公平，並防止濫用、攻擊、繞過限流或大量自動化請求，我們也會收集並保留必要的防濫用資訊，包括連線 IP、網站使用者識別碼（如有）、請求時間、限流紀錄與相關技術紀錄。</p>
+							<p>上述資訊只會用於提供服務、維護服務安全、偵測異常流量、建立或執行防濫用名單、處理資安事件，以及遵循法律或主管機關要求；不會用於廣告投放，也不會出售給第三方。除非發現濫用、攻擊、規避限流或其他不當使用疑慮，或依法必須提供，否則我們不會將您的提問內容或可識別資訊提供給第三方。</p>
+							<p>本服務依 Cloudflare Workers 等基礎設施的運作機制接收必要的請求資訊。除為提供服務、維護安全、防止濫用或依法所需外，我們不會主動蒐集或留存其他可識別您的個人資料。</p>
+						</div>
+					</section>
+					<section class="legal-page__section legal-page__section--alt" aria-labelledby="privacy-en">
+						<h2 id="privacy-en"><span lang="en">English</span></h2>
+						<div lang="en">
+							<p>We hope the AI question feature on this site can serve as a friendly, open, and sustainable public knowledge gateway where people can ask, share, and learn with confidence.</p>
+							<p>We do not sell or exchange your personal data, and do not build an advertising profile of you.</p>
+							<p>When you ask a question in the search box, we collect and retain the questions you submit to generate replies, maintain service quality, detect abuse, and handle security incidents.</p>
+							<p>To keep the service stable and fair for everyone, and to prevent abuse, attacks, rate-limit bypasses, or large-scale automated requests, we also collect and retain necessary anti-abuse information, including connection IP addresses, website user IDs (if available), request times, rate-limit records, and related technical logs.</p>
+							<p>This information is used only to provide the service, maintain service security, detect abnormal traffic, create or enforce anti-abuse lists, handle security incidents, and comply with legal or regulatory requirements. It is not used for advertising and is not sold to third parties. Unless we identify suspected abuse, attacks, rate-limit circumvention, or other improper use, or are legally required to do so, we do not provide your question content or identifiable information to third parties.</p>
+							<p>The service may receive request information required by its hosting infrastructure to operate. Except as needed to provide the service, maintain security, prevent abuse, or comply with law, we do not otherwise actively collect or retain personal data that identifies you.</p>
+							<p><em>This English version is provided for convenience; if it and the Chinese version differ, the Chinese version governs.</em></p>
+						</div>
+					</section>
+					<nav class="legal-page__nav" aria-label="Legal pages">
+						<a href="/"><span lang="zh">首頁</span><span lang="en">Home</span></a>
+						<a href="/terms"><span lang="zh">使用條款</span><span lang="en">Terms of Use</span></a>
+					</nav>
+				</div>
+			</div>
+		</div>
+		<Footer />
+	</div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+.legal-page {
+	max-width: 760px;
+	padding: 2rem 0 3rem;
+	line-height: 1.7;
+}
+.legal-page h1 {
+	margin: 0 0 1.5rem;
+	font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+.legal-page__section h2 {
+	margin: 2rem 0 0.75rem;
+	font-size: 1.25rem;
+}
+.legal-page__section p {
+	margin: 0 0 1rem;
+}
+.legal-page__section--alt {
+	padding-top: 1.75rem;
+	border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+.legal-page__nav {
+	margin-top: 2rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+@media (prefers-color-scheme: dark) {
+	.legal-page__section--alt {
+		border-color: rgba(255, 255, 255, 0.15);
+	}
+}
+</style>

--- a/src/views/LegalTermsView.vue
+++ b/src/views/LegalTermsView.vue
@@ -1,0 +1,81 @@
+<template>
+	<div class="page">
+		<Navbar />
+		<div class="full-page">
+			<div class="full-page__row">
+				<div class="full-page__unit legal-page">
+					<h1><span lang="zh">使用條款</span><span lang="en">Terms of Use</span></h1>
+					<section class="legal-page__section" aria-labelledby="terms-zh">
+						<h2 id="terms-zh"><span lang="zh">華語</span></h2>
+						<div lang="zh">
+							<p>我們歡迎您以好奇、善意與負責任的方式使用本站的 AI 提問與搜尋功能，探索唐鳳的公開談話、引用有出處的內容，並與更多人分享公共知識。</p>
+							<p>使用本服務前，請先閱讀並同意本使用條款與 <a href="/privacy">隱私權政策</a>。若您不同意，請勿使用本服務。</p>
+							<p>為維護服務穩定、提供回覆、避免濫用、攻擊、繞過限流或大量自動化請求，您同意我們依隱私權政策收集並使用必要資訊，包括您提出的問題、連線 IP、網站使用者識別碼（如有）、請求時間、限流紀錄與相關技術紀錄。除非發現濫用疑慮或依法必須提供，否則我們不會將您的提問內容或可識別資訊提供給第三方。</p>
+							<p>您不得以自動化、偽造身分、變更來源、分散流量或其他方式規避限流、封鎖或安全措施；如有濫用、攻擊或不當使用情事，我們得暫停、限制或封鎖相關請求，並保留法律追訴權。</p>
+							<p>AI 回應之內容採用 Creative Commons Attribution-ShareAlike（CC BY-SA，姓名標示-相同方式分享）授權。</p>
+							<p>您可以在合理使用及註明出處後引用、分享、改作或進行衍生創作；衍生內容亦應依 CC BY-SA 的精神，以相同或相容授權方式分享。</p>
+							<p>上述授權不包含惡意的斷章取義、變造文句、截圖加工，或其他足以誤導他人、損害原意或侵害權益的使用方式。</p>
+							<p>如有惡意使用、誤導性使用或其他不當使用情事，我們保留法律追訴權。</p>
+						</div>
+					</section>
+					<section class="legal-page__section legal-page__section--alt" aria-labelledby="terms-en">
+						<h2 id="terms-en"><span lang="en">English</span></h2>
+						<div lang="en">
+							<p>We welcome you to use this site’s AI question and search features with curiosity, goodwill, and responsibility: explore Audrey Tang's public talks, cite sourced content, and share public knowledge with others.</p>
+							<p>Before using this service, please read and agree to these Terms of Use and the <a href="/privacy">Privacy Policy</a>. If you do not agree, please do not use the service.</p>
+							<p>To maintain service stability, provide replies, and prevent abuse, attacks, rate-limit bypasses, or large-scale automated requests, you agree that we may collect and use necessary information as described in the Privacy Policy, including the questions you submit, connection IP addresses, website user IDs (if available), request times, rate-limit records, and related technical logs. Unless we identify suspected abuse or are legally required to do so, we do not provide your question content or identifiable information to third parties.</p>
+							<p>You may not use automation, forged identities, changed origins, distributed traffic, or other methods to circumvent rate limits, blocks, or security measures. In cases of abuse, attacks, or improper use, we may suspend, restrict, or block related requests and reserve the right to pursue legal action.</p>
+							<p>Content provided in AI replies is licensed under Creative Commons Attribution-ShareAlike (CC BY-SA).</p>
+							<p>You may quote, share, adapt, or create derivative works from the content after making reasonable use and providing proper attribution. Derivative works should also be shared under the same or a compatible license in the spirit of CC BY-SA.</p>
+							<p>This permission does not include malicious quotation out of context, alteration of wording, edited screenshots, or any other use that may mislead others, distort the original meaning, or infringe rights.</p>
+							<p>We reserve the right to pursue legal action in cases of malicious, misleading, or otherwise improper use.</p>
+							<p><em>This English version is provided for convenience; if it and the Chinese version differ, the Chinese version governs.</em></p>
+						</div>
+					</section>
+					<nav class="legal-page__nav" aria-label="Legal pages">
+						<a href="/"><span lang="zh">首頁</span><span lang="en">Home</span></a>
+						<a href="/privacy"><span lang="zh">隱私權政策</span><span lang="en">Privacy Policy</span></a>
+					</nav>
+				</div>
+			</div>
+		</div>
+		<Footer />
+	</div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+.legal-page {
+	max-width: 760px;
+	padding: 2rem 0 3rem;
+	line-height: 1.7;
+}
+.legal-page h1 {
+	margin: 0 0 1.5rem;
+	font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+.legal-page__section h2 {
+	margin: 2rem 0 0.75rem;
+	font-size: 1.25rem;
+}
+.legal-page__section p {
+	margin: 0 0 1rem;
+}
+.legal-page__section--alt {
+	padding-top: 1.75rem;
+	border-top: 1px solid rgba(0, 0, 0, 0.12);
+}
+.legal-page__nav {
+	margin-top: 2rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+@media (prefers-color-scheme: dark) {
+	.legal-page__section--alt {
+		border-color: rgba(255, 255, 255, 0.15);
+	}
+}
+</style>

--- a/src/views/NestedSpeechView.vue
+++ b/src/views/NestedSpeechView.vue
@@ -36,9 +36,6 @@ const getNestUrl = (nestFilename: string) =>
 					</button>
 				</div>
 			</div>
-			<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
-				{{ alternateLabel }}
-			</a>
 		</Navbar>
 		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>

--- a/src/views/NestedSpeechView.vue
+++ b/src/views/NestedSpeechView.vue
@@ -26,7 +26,7 @@ const getNestUrl = (nestFilename: string) =>
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-								<div class="sayit-search__row">
+				<div class="sayit-search__row">
 					<div class="sayit-search__input-wrap">
 						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
@@ -41,12 +41,7 @@ const getNestUrl = (nestFilename: string) =>
 			</a>
 		</Navbar>
 		<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-			<p class="homepage-ask__intro">
-				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-				<span lang="en">Or ask a question and let AI search the transcripts:</span>
-			</p>
-			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>

--- a/src/views/NestedSpeechView.vue
+++ b/src/views/NestedSpeechView.vue
@@ -35,6 +35,15 @@ const getNestUrl = (nestFilename: string) =>
 				{{ alternateLabel }}
 			</a>
 		</Navbar>
+		<div id="sayit-ask" class="homepage-ask" hidden>
+			<p class="homepage-ask__intro">
+				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+				<span lang="en">Or ask a question and let AI search the transcripts:</span>
+			</p>
+			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		</div>
+		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page">
 			<div class="full-page__row">

--- a/src/views/NestedSpeechView.vue
+++ b/src/views/NestedSpeechView.vue
@@ -26,15 +26,21 @@ const getNestUrl = (nestFilename: string) =>
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-				<div class="sayit-search__input-wrap">
-					<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
-					<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+					<div class="sayit-search__input-wrap">
+						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+					</div>
+					<button type="button" class="sayit-search__submit" aria-label="Search">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+					</button>
 				</div>
 			</div>
 			<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
 				{{ alternateLabel }}
 			</a>
 		</Navbar>
+		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden>
 			<p class="homepage-ask__intro">
 				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
@@ -43,7 +49,8 @@ const getNestUrl = (nestFilename: string) =>
 			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+		</div>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page">
 			<div class="full-page__row">

--- a/src/views/SearchResultView.vue
+++ b/src/views/SearchResultView.vue
@@ -2,12 +2,18 @@
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-				<div class="sayit-search__input-wrap">
-					<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
-					<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+					<div class="sayit-search__input-wrap">
+						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+					</div>
+					<button type="button" class="sayit-search__submit" aria-label="Search">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+					</button>
 				</div>
 			</div>
 		</Navbar>
+		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden>
 			<p class="homepage-ask__intro">
 				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
@@ -16,7 +22,8 @@
 			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+		</div>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page">
 			<div class="full-page__row">

--- a/src/views/SearchResultView.vue
+++ b/src/views/SearchResultView.vue
@@ -19,6 +19,22 @@
 							<input type="submit" class="icon-search" value="Search" />
 						</div>
 					</form>
+					<div id="sayit-ask" class="homepage-ask" hidden>
+						<p class="homepage-ask__intro">
+							<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+							<span lang="en">Or ask a question and let AI search the transcripts:</span>
+						</p>
+						<label class="homepage-ask__consent" id="sayit-ask-consent-label">
+							<input type="checkbox" id="sayit-ask-consent">
+							<span>
+								<span lang="zh">我已閱讀並同意 <a href="https://ask.archive.tw/privacy" target="_blank" rel="noopener noreferrer">隱私權政策</a> 和 <a href="https://ask.archive.tw/terms" target="_blank" rel="noopener noreferrer">使用條款</a></span>
+								<span lang="en">I have read and agree to the <a href="https://ask.archive.tw/en/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and the <a href="https://ask.archive.tw/en/terms" target="_blank" rel="noopener noreferrer">Terms of Use</a></span>
+							</span>
+						</label>
+						<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+						<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+						<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+					</div>
 					<div class="page-content__row ">
 						<div class="full-page__unit">
 							<!-- 當有講者篩選時，顯示 checkbox -->

--- a/src/views/SearchResultView.vue
+++ b/src/views/SearchResultView.vue
@@ -2,7 +2,7 @@
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-								<div class="sayit-search__row">
+				<div class="sayit-search__row">
 					<div class="sayit-search__input-wrap">
 						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
@@ -14,12 +14,7 @@
 			</div>
 		</Navbar>
 		<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-			<p class="homepage-ask__intro">
-				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-				<span lang="en">Or ask a question and let AI search the transcripts:</span>
-			</p>
-			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>

--- a/src/views/SearchResultView.vue
+++ b/src/views/SearchResultView.vue
@@ -8,6 +8,15 @@
 				</div>
 			</div>
 		</Navbar>
+		<div id="sayit-ask" class="homepage-ask" hidden>
+			<p class="homepage-ask__intro">
+				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+				<span lang="en">Or ask a question and let AI search the transcripts:</span>
+			</p>
+			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		</div>
+		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page">
 			<div class="full-page__row">
@@ -19,22 +28,6 @@
 							<input type="submit" class="icon-search" value="Search" />
 						</div>
 					</form>
-					<div id="sayit-ask" class="homepage-ask" hidden>
-						<p class="homepage-ask__intro">
-							<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-							<span lang="en">Or ask a question and let AI search the transcripts:</span>
-						</p>
-						<label class="homepage-ask__consent" id="sayit-ask-consent-label">
-							<input type="checkbox" id="sayit-ask-consent">
-							<span>
-								<span lang="zh">我已閱讀並同意 <a href="https://ask.archive.tw/privacy" target="_blank" rel="noopener noreferrer">隱私權政策</a> 和 <a href="https://ask.archive.tw/terms" target="_blank" rel="noopener noreferrer">使用條款</a></span>
-								<span lang="en">I have read and agree to the <a href="https://ask.archive.tw/en/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a> and the <a href="https://ask.archive.tw/en/terms" target="_blank" rel="noopener noreferrer">Terms of Use</a></span>
-							</span>
-						</label>
-						<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
-						<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-						<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
-					</div>
 					<div class="page-content__row ">
 						<div class="full-page__unit">
 							<!-- 當有講者篩選時，顯示 checkbox -->

--- a/src/views/SingleNestedSpeechView.vue
+++ b/src/views/SingleNestedSpeechView.vue
@@ -156,9 +156,6 @@
 						</button>
 					</div>
 				</div>
-				<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
-					{{ alternateLabel }}
-				</a>
 			</Navbar>
 			<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>

--- a/src/views/SingleNestedSpeechView.vue
+++ b/src/views/SingleNestedSpeechView.vue
@@ -155,6 +155,15 @@
 					{{ alternateLabel }}
 				</a>
 			</Navbar>
+			<div id="sayit-ask" class="homepage-ask" hidden>
+				<p class="homepage-ask__intro">
+					<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+					<span lang="en">Or ask a question and let AI search the transcripts:</span>
+				</p>
+				<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+			</div>
+			<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+			<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 			<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 			<div class="full-page">
 				<div class="full-page__row">

--- a/src/views/SingleNestedSpeechView.vue
+++ b/src/views/SingleNestedSpeechView.vue
@@ -146,16 +146,22 @@
 		<div class="page">
 			<Navbar>
 				<div id="sayit-search" class="sayit-search" role="search">
-					<div class="sayit-search__input-wrap">
-						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
-						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
-					</div>
-				</div>
+											<div class="sayit-search__row">
+							<div class="sayit-search__input-wrap">
+								<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+								<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+							</div>
+							<button type="button" class="sayit-search__submit" aria-label="Search">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+							</button>
+						</div>
+			</div>
 				<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
 					{{ alternateLabel }}
 				</a>
 			</Navbar>
-			<div id="sayit-ask" class="homepage-ask" hidden>
+			<div class="sayit-ask-overlay">
+		<div id="sayit-ask" class="homepage-ask" hidden>
 				<p class="homepage-ask__intro">
 					<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
 					<span lang="en">Or ask a question and let AI search the transcripts:</span>
@@ -163,7 +169,8 @@
 				<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 			</div>
 			<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-			<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+			<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+			</div>
 			<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 			<div class="full-page">
 				<div class="full-page__row">

--- a/src/views/SingleNestedSpeechView.vue
+++ b/src/views/SingleNestedSpeechView.vue
@@ -145,28 +145,23 @@
 	<template>
 		<div class="page">
 			<Navbar>
-				<div id="sayit-search" class="sayit-search" role="search">
-											<div class="sayit-search__row">
-							<div class="sayit-search__input-wrap">
+								<div id="sayit-search" class="sayit-search" role="search">
+					<div class="sayit-search__row">
+						<div class="sayit-search__input-wrap">
 								<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 								<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
-							</div>
-							<button type="button" class="sayit-search__submit" aria-label="Search">
-								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
-							</button>
 						</div>
-			</div>
+						<button type="button" class="sayit-search__submit" aria-label="Search">
+								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+						</button>
+					</div>
+				</div>
 				<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
 					{{ alternateLabel }}
 				</a>
 			</Navbar>
 			<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-				<p class="homepage-ask__intro">
-					<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-					<span lang="en">Or ask a question and let AI search the transcripts:</span>
-				</p>
-				<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 			</div>
 			<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 			<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>

--- a/src/views/SingleParagraphView.vue
+++ b/src/views/SingleParagraphView.vue
@@ -71,6 +71,15 @@ const getParagraphUrl = (sectionId: number) => `/speech/${sectionId}`;
 				</div>
 			</div>
 		</Navbar>
+		<div id="sayit-ask" class="homepage-ask" hidden>
+			<p class="homepage-ask__intro">
+				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+				<span lang="en">Or ask a question and let AI search the transcripts:</span>
+			</p>
+			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		</div>
+		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page" v-if="section">
 			<div class="full-page__row">

--- a/src/views/SingleParagraphView.vue
+++ b/src/views/SingleParagraphView.vue
@@ -65,12 +65,18 @@ const getParagraphUrl = (sectionId: number) => `/speech/${sectionId}`;
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-				<div class="sayit-search__input-wrap">
-					<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
-					<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+					<div class="sayit-search__input-wrap">
+						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+					</div>
+					<button type="button" class="sayit-search__submit" aria-label="Search">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+					</button>
 				</div>
 			</div>
 		</Navbar>
+		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden>
 			<p class="homepage-ask__intro">
 				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
@@ -79,7 +85,8 @@ const getParagraphUrl = (sectionId: number) => `/speech/${sectionId}`;
 			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+		</div>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page" v-if="section">
 			<div class="full-page__row">

--- a/src/views/SingleParagraphView.vue
+++ b/src/views/SingleParagraphView.vue
@@ -65,7 +65,7 @@ const getParagraphUrl = (sectionId: number) => `/speech/${sectionId}`;
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-								<div class="sayit-search__row">
+				<div class="sayit-search__row">
 					<div class="sayit-search__input-wrap">
 						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
@@ -77,12 +77,7 @@ const getParagraphUrl = (sectionId: number) => `/speech/${sectionId}`;
 			</div>
 		</Navbar>
 		<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-			<p class="homepage-ask__intro">
-				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-				<span lang="en">Or ask a question and let AI search the transcripts:</span>
-			</p>
-			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>

--- a/src/views/SingleSpeakerView.vue
+++ b/src/views/SingleSpeakerView.vue
@@ -246,6 +246,15 @@ const formatLongestSectionSummary = (summary: string) => {
 				</div>
 			</div>
 		</Navbar>
+		<div id="sayit-ask" class="homepage-ask" hidden>
+			<p class="homepage-ask__intro">
+				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+				<span lang="en">Or ask a question and let AI search the transcripts:</span>
+			</p>
+			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		</div>
+		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page" v-if="speaker">
 			<div class="full-page__row">

--- a/src/views/SingleSpeakerView.vue
+++ b/src/views/SingleSpeakerView.vue
@@ -240,7 +240,7 @@ const formatLongestSectionSummary = (summary: string) => {
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-								<div class="sayit-search__row">
+				<div class="sayit-search__row">
 					<div class="sayit-search__input-wrap">
 						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
@@ -252,12 +252,7 @@ const formatLongestSectionSummary = (summary: string) => {
 			</div>
 		</Navbar>
 		<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-			<p class="homepage-ask__intro">
-				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-				<span lang="en">Or ask a question and let AI search the transcripts:</span>
-			</p>
-			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>

--- a/src/views/SingleSpeakerView.vue
+++ b/src/views/SingleSpeakerView.vue
@@ -240,12 +240,18 @@ const formatLongestSectionSummary = (summary: string) => {
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-				<div class="sayit-search__input-wrap">
-					<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
-					<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+					<div class="sayit-search__input-wrap">
+						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+					</div>
+					<button type="button" class="sayit-search__submit" aria-label="Search">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+					</button>
 				</div>
 			</div>
 		</Navbar>
+		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden>
 			<p class="homepage-ask__intro">
 				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
@@ -254,7 +260,8 @@ const formatLongestSectionSummary = (summary: string) => {
 			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+		</div>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page" v-if="speaker">
 			<div class="full-page__row">

--- a/src/views/SingleSpeechView.vue
+++ b/src/views/SingleSpeechView.vue
@@ -110,6 +110,15 @@ const loading = false
 				{{ alternateLabel }}
 			</a>
 		</Navbar>
+		<div id="sayit-ask" class="homepage-ask" hidden>
+			<p class="homepage-ask__intro">
+				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+				<span lang="en">Or ask a question and let AI search the transcripts:</span>
+			</p>
+			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		</div>
+		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page">
 			<div class="full-page__row">

--- a/src/views/SingleSpeechView.vue
+++ b/src/views/SingleSpeechView.vue
@@ -111,9 +111,6 @@ const loading = false
 					</button>
 				</div>
 			</div>
-			<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
-				{{ alternateLabel }}
-			</a>
 		</Navbar>
 		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>

--- a/src/views/SingleSpeechView.vue
+++ b/src/views/SingleSpeechView.vue
@@ -101,7 +101,7 @@ const loading = false
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-								<div class="sayit-search__row">
+				<div class="sayit-search__row">
 					<div class="sayit-search__input-wrap">
 						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
@@ -116,12 +116,7 @@ const loading = false
 			</a>
 		</Navbar>
 		<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-			<p class="homepage-ask__intro">
-				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-				<span lang="en">Or ask a question and let AI search the transcripts:</span>
-			</p>
-			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>

--- a/src/views/SingleSpeechView.vue
+++ b/src/views/SingleSpeechView.vue
@@ -101,15 +101,21 @@ const loading = false
 	<div class="page">
 		<Navbar>
 			<div id="sayit-search" class="sayit-search" role="search">
-				<div class="sayit-search__input-wrap">
-					<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
-					<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+					<div class="sayit-search__input-wrap">
+						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+					</div>
+					<button type="button" class="sayit-search__submit" aria-label="Search">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+					</button>
 				</div>
 			</div>
 			<a v-if="alternateUrl" :href="alternateUrl" class="sayit-lang-switch" :title="alternateLabel">
 				{{ alternateLabel }}
 			</a>
 		</Navbar>
+		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden>
 			<p class="homepage-ask__intro">
 				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
@@ -118,7 +124,8 @@ const loading = false
 			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
-		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden aria-hidden="true"></button>
+		</div>
 		<div id="sayit-search-results" class="sayit-search__results" aria-live="polite" hidden></div>
 		<div class="full-page">
 			<div class="full-page__row">

--- a/src/views/SpeechesView.vue
+++ b/src/views/SpeechesView.vue
@@ -43,19 +43,18 @@ const sortedSpeeches = computed(() => {
 		<Navbar>
 			<!-- Pagefind search widget in navbar -->
 			<div id="sayit-search" class="sayit-search" role="search">
-				<div class="sayit-search__input-wrap">
-					<input
-						id="sayit-search-input"
-						type="search"
-						class="sayit-search__input"
-						autocomplete="off"
-						spellcheck="false"
-						aria-label="Search speeches"
-					>
-					<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+								<div class="sayit-search__row">
+					<div class="sayit-search__input-wrap">
+						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
+						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
+					</div>
+					<button type="button" class="sayit-search__submit" aria-label="Search">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+					</button>
 				</div>
 			</div>
 		</Navbar>
+		<div class="sayit-ask-overlay">
 		<div id="sayit-ask" class="homepage-ask" hidden>
 			<p class="homepage-ask__intro">
 				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>

--- a/src/views/SpeechesView.vue
+++ b/src/views/SpeechesView.vue
@@ -56,6 +56,15 @@ const sortedSpeeches = computed(() => {
 				</div>
 			</div>
 		</Navbar>
+		<div id="sayit-ask" class="homepage-ask" hidden>
+			<p class="homepage-ask__intro">
+				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
+				<span lang="en">Or ask a question and let AI search the transcripts:</span>
+			</p>
+			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		</div>
+		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
+		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>
 		<div class="full-page">
 			<div class="full-page__row">
 				<div class="full-page__unit">

--- a/src/views/SpeechesView.vue
+++ b/src/views/SpeechesView.vue
@@ -43,7 +43,7 @@ const sortedSpeeches = computed(() => {
 		<Navbar>
 			<!-- Pagefind search widget in navbar -->
 			<div id="sayit-search" class="sayit-search" role="search">
-								<div class="sayit-search__row">
+				<div class="sayit-search__row">
 					<div class="sayit-search__input-wrap">
 						<input id="sayit-search-input" type="search" class="sayit-search__input" autocomplete="off" spellcheck="false" aria-label="Search speeches">
 						<span class="sayit-search__shortcut" id="sayit-search-shortcut" aria-hidden="true">/</span>
@@ -55,12 +55,7 @@ const sortedSpeeches = computed(() => {
 			</div>
 		</Navbar>
 		<div class="sayit-ask-overlay">
-		<div id="sayit-ask" class="homepage-ask" hidden>
-			<p class="homepage-ask__intro">
-				<span lang="zh">或直接提問，讓 AI 從逐字稿中找出回答：</span>
-				<span lang="en">Or ask a question and let AI search the transcripts:</span>
-			</p>
-			<p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
+		<div id="sayit-ask" class="homepage-ask" hidden><p id="sayit-ask-status" class="homepage-ask__status" aria-live="polite"></p>
 		</div>
 		<div id="sayit-ask-answer" class="homepage-ask-answer" aria-live="polite" hidden></div>
 		<button type="button" id="sayit-ask-submit" class="homepage-ask__submit" hidden></button>

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -3,6 +3,7 @@ import { renderHtml } from '../src/ssr/render';
 import HomeView, { styles as HomeViewStyles } from '../src/.generated/views/HomeView';
 import Navbar, { styles as NavbarStyles } from '../src/.generated/components/Navbar';
 import Footer, { styles as FooterStyles } from '../src/.generated/components/Footer';
+import SearchResultView, { styles as SearchResultViewStyles } from '../src/.generated/views/SearchResultView';
 
 describe('SSR layout', () => {
 	it('renders the global share control and share script', async () => {
@@ -29,7 +30,31 @@ describe('SSR layout', () => {
 		expect(html).toContain('class="homepage-search__row"');
 		expect(html).toContain('https://ask.archive.tw/privacy');
 		expect(html).toContain('https://ask.archive.tw/en/privacy');
+		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
+		expect(html.indexOf('id="sayit-ask-answer"')).toBeLessThan(html.indexOf('id="sayit-search-results"'));
+	});
+
+	it('renders the search results page Ask UI above regular results', async () => {
+		const html = await renderHtml(SearchResultView, {
+			styles: [SearchResultViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n'),
+			components: { Navbar, Footer },
+			props: {
+				query: 'ochiai',
+				speakers: [],
+				sections: [],
+				page: 1,
+				page_size: 20,
+				total_pages: 1,
+				total_sections: 0,
+				pagination_pages: [1]
+			}
+		});
+
+		expect(html).toContain('id="sayit-ask"');
+		expect(html).toContain('id="sayit-ask-consent"');
+		expect(html).toContain('id="sayit-ask-status"');
 		expect(html).toContain('id="sayit-ask-answer"');
 		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
+		expect(html.indexOf('id="sayit-ask-answer"')).toBeLessThan(html.indexOf('unstyled-list search-results-speakers'));
 	});
 });

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -24,7 +24,11 @@ describe('SSR layout', () => {
 
 		expect(html).toContain('id="sayit-ask"');
 		expect(html).toContain('class="homepage-ask" hidden');
+		expect(html).toContain('id="sayit-ask-consent"');
 		expect(html).toContain('id="sayit-ask-submit"');
+		expect(html).toContain('class="homepage-search__row"');
+		expect(html).toContain('https://ask.archive.tw/privacy');
+		expect(html).toContain('https://ask.archive.tw/en/privacy');
 		expect(html).toContain('id="sayit-ask-answer"');
 		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
 	});

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -15,4 +15,17 @@ describe('SSR layout', () => {
 		expect(html).toContain('sayit-share-feedback');
 		expect(html).toContain('navigator.share');
 	});
+
+	it('renders the homepage Ask UI hidden by default', async () => {
+		const html = await renderHtml(HomeView, {
+			styles: [HomeViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n'),
+			components: { Navbar, Footer }
+		});
+
+		expect(html).toContain('id="sayit-ask"');
+		expect(html).toContain('class="homepage-ask" hidden');
+		expect(html).toContain('id="sayit-ask-submit"');
+		expect(html).toContain('id="sayit-ask-answer"');
+		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
+	});
 });

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -4,6 +4,7 @@ import HomeView, { styles as HomeViewStyles } from '../src/.generated/views/Home
 import Navbar, { styles as NavbarStyles } from '../src/.generated/components/Navbar';
 import Footer, { styles as FooterStyles } from '../src/.generated/components/Footer';
 import SearchResultView, { styles as SearchResultViewStyles } from '../src/.generated/views/SearchResultView';
+import LegalPrivacyView, { styles as LegalPrivacyViewStyles } from '../src/.generated/views/LegalPrivacyView';
 
 describe('SSR layout', () => {
 	it('renders the global share control and share script', async () => {
@@ -25,13 +26,23 @@ describe('SSR layout', () => {
 
 		expect(html).toContain('id="sayit-ask"');
 		expect(html).toContain('class="homepage-ask" hidden');
-		expect(html).toContain('id="sayit-ask-consent"');
+		expect(html).not.toContain('id="sayit-ask-consent"');
 		expect(html).toContain('id="sayit-ask-submit"');
 		expect(html).toContain('class="homepage-search__row"');
-		expect(html).toContain('https://ask.archive.tw/privacy');
-		expect(html).toContain('https://ask.archive.tw/en/privacy');
 		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
 		expect(html.indexOf('id="sayit-ask-answer"')).toBeLessThan(html.indexOf('id="sayit-search-results"'));
+	});
+
+	it('renders footer ask notice with local privacy and terms links', async () => {
+		const html = await renderHtml(HomeView, {
+			styles: [HomeViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n'),
+			components: { Navbar, Footer }
+		});
+
+		expect(html).toContain('sayit-footer-ask-notice');
+		expect(html).toContain('href="/privacy"');
+		expect(html).toContain('href="/terms"');
+		expect(html).not.toContain('ask.archive.tw/privacy');
 	});
 
 	it('renders the search results page Ask UI above regular results', async () => {
@@ -51,10 +62,22 @@ describe('SSR layout', () => {
 		});
 
 		expect(html).toContain('id="sayit-ask"');
-		expect(html).toContain('id="sayit-ask-consent"');
+		expect(html).not.toContain('id="sayit-ask-consent"');
 		expect(html).toContain('id="sayit-ask-status"');
 		expect(html).toContain('id="sayit-ask-answer"');
 		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
 		expect(html.indexOf('id="sayit-ask-answer"')).toBeLessThan(html.indexOf('unstyled-list search-results-speakers'));
+	});
+
+	it('renders bilingual privacy policy content', async () => {
+		const html = await renderHtml(LegalPrivacyView, {
+			styles: [LegalPrivacyViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n'),
+			components: { Navbar, Footer }
+		});
+
+		expect(html).toContain('id="privacy-zh"');
+		expect(html).toContain('id="privacy-en"');
+		expect(html).toContain('不會販售或交換您的個人資料');
+		expect(html).toContain('We do not sell or exchange your personal data');
 	});
 });

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -18,6 +18,16 @@ describe('SSR layout', () => {
 		expect(html).toContain('navigator.share');
 	});
 
+	it('navbar share control has no legacy margin-top in SSR CSS', async () => {
+		const html = await renderHtml(HomeView, {
+			styles: [HomeViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n'),
+			components: { Navbar, Footer }
+		});
+
+		expect(html).not.toContain('margin-top: 5px');
+		expect(html).toContain('margin: 0 !important');
+	});
+
 	it('renders the homepage Ask UI hidden by default', async () => {
 		const html = await renderHtml(HomeView, {
 			styles: [HomeViewStyles, NavbarStyles, FooterStyles].filter(Boolean).join('\n'),

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -34,6 +34,7 @@ describe('SSR layout', () => {
 			components: { Navbar, Footer }
 		});
 
+		expect(html).toContain('id="sayit-site-lang-toggle"');
 		expect(html).toContain('id="sayit-ask"');
 		expect(html).toContain('class="homepage-ask" hidden');
 		expect(html).not.toContain('id="sayit-ask-consent"');
@@ -77,6 +78,7 @@ describe('SSR layout', () => {
 		expect(html).toContain('id="sayit-ask-answer"');
 		expect(html).toContain('class="homepage-ask-answer" aria-live="polite" hidden');
 		expect(html.indexOf('id="sayit-ask-answer"')).toBeLessThan(html.indexOf('unstyled-list search-results-speakers'));
+		expect(html).not.toContain('id="sayit-site-lang-toggle"');
 	});
 
 	it('renders bilingual privacy policy content', async () => {

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -43,6 +43,23 @@
 	var askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
 	input.setAttribute('placeholder', askT.searchPlaceholder);
 	input.setAttribute('aria-label', askT.searchAriaLabel);
+	function refreshSearchI18n() {
+		isZh = document.documentElement.classList.contains('lang-zh');
+		askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
+		input.setAttribute('placeholder', askT.searchPlaceholder);
+		input.setAttribute('aria-label', askT.searchAriaLabel);
+		updateAskControls();
+	}
+
+	var searchSubmitButtons = document.querySelectorAll('.sayit-search__submit');
+	for (var si = 0; si < searchSubmitButtons.length; si++) {
+		searchSubmitButtons[si].addEventListener('click', function () {
+			submitSearch(input.value);
+		});
+	}
+	for (var sb = 0; sb < searchSubmitButtons.length; sb++) searchSubmitButtons[sb].hidden = false;
+
+	window.addEventListener('sayit-lang-change', refreshSearchI18n);
 
 	var worker = null;
 	var debounceTimer = null;
@@ -557,6 +574,7 @@
 			if (!data || data.status !== 'available') return;
 			askAvailable = true;
 			if (askPanel) askPanel.hidden = false;
+			for (var sb = 0; sb < searchSubmitButtons.length; sb++) searchSubmitButtons[sb].hidden = false;
 			updateAskControls();
 		}).catch(function () {
 			askAvailable = false;

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -7,13 +7,41 @@
 	var speechList = document.getElementById('sayit-speech-list');
 	var askPanel = document.getElementById('sayit-ask');
 	var askSubmit = document.getElementById('sayit-ask-submit');
+	var askConsent = document.getElementById('sayit-ask-consent');
 	var askStatus = document.getElementById('sayit-ask-status');
 	var askAnswer = document.getElementById('sayit-ask-answer');
 	if (!input || !results) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
-	input.setAttribute('placeholder', isZh ? '搜尋對話內容…' : 'Search speeches…');
-	if (isZh) input.setAttribute('aria-label', '搜尋對話');
+	var ASK_STRINGS = {
+		zh: {
+			searchPlaceholder: '搜尋對話內容…',
+			searchAriaLabel: '搜尋對話',
+			submit: '💬 提問',
+			submitting: '💬 提問中…',
+			cooldown: function (seconds) { return '💬 ' + seconds + ' 秒後可再提問'; },
+			searching: '檢索逐字稿中…',
+			sourcesHeading: '出處',
+			questionTooLong: '問題太長，請縮短到 100 字以內。',
+			fetchError: '提問服務暫時無法使用，請稍後再試。',
+			networkError: '連線發生錯誤，請稍後再試。',
+		},
+		en: {
+			searchPlaceholder: 'Search speeches…',
+			searchAriaLabel: 'Search speeches',
+			submit: '💬 Ask',
+			submitting: '💬 Asking…',
+			cooldown: function (seconds) { return '💬 Ask again in ' + seconds + ' s'; },
+			searching: 'Searching the transcripts…',
+			sourcesHeading: 'Sources',
+			questionTooLong: 'Your question is too long. Please shorten it to 100 characters or fewer.',
+			fetchError: 'The ask service is temporarily unavailable. Please try again later.',
+			networkError: 'Connection error. Please try again later.',
+		},
+	};
+	var askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
+	input.setAttribute('placeholder', askT.searchPlaceholder);
+	input.setAttribute('aria-label', askT.searchAriaLabel);
 
 	var worker = null;
 	var debounceTimer = null;
@@ -179,18 +207,25 @@
 		if (askStatus) askStatus.textContent = message || '';
 	}
 
+	function consentAccepted() {
+		return askConsent ? askConsent.checked : false;
+	}
+
 	function updateAskControls() {
-		if (!askPanel || !askSubmit) return;
+		if (!askSubmit) return;
 		var hasQuestion = Boolean(input.value.trim());
 		var disabled = askLoading || askCooldownRemaining > 0;
-		askSubmit.disabled = disabled || !hasQuestion;
+		var canAsk = consentAccepted();
+		askSubmit.disabled = disabled || !hasQuestion || !canAsk;
 		askSubmit.textContent = askLoading
-			? '💬 提問中…'
-			: (askCooldownRemaining > 0 ? '💬 ' + askCooldownRemaining + ' 秒後可再提問' : '💬 提問');
+			? askT.submitting
+			: (askCooldownRemaining > 0 ? askT.cooldown(askCooldownRemaining) : askT.submit);
+		if (askConsent) askConsent.disabled = askLoading;
 
+		if (!askPanel) return;
 		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
 		for (var i = 0; i < samples.length; i++) {
-			samples[i].disabled = disabled;
+			samples[i].disabled = disabled || !canAsk;
 		}
 	}
 
@@ -224,7 +259,7 @@
 		var parsed = parseAskAnswer(raw);
 		var html = '';
 		if (!parsed.html && loading) {
-			html += '<p class="homepage-ask-answer__status">檢索逐字稿中…</p>';
+			html += '<p class="homepage-ask-answer__status">' + escapeHtml(askT.searching) + '</p>';
 		}
 		if (parsed.html) {
 			html += '<div class="homepage-ask-answer__body">' + parsed.html + '</div>';
@@ -233,7 +268,7 @@
 			html += '<span class="homepage-ask-answer__cursor" aria-hidden="true">▌</span>';
 		}
 		if (parsed.sources.length > 0) {
-			html += '<div class="homepage-ask-answer__sources"><h3>出處</h3><ol>';
+			html += '<div class="homepage-ask-answer__sources"><h3>' + escapeHtml(askT.sourcesHeading) + '</h3><ol>';
 			for (var i = 0; i < parsed.sources.length; i++) {
 				var source = parsed.sources[i];
 				html += '<li value="' + source.index + '"><a href="' + escapeHtml(source.href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(source.label) + '</a></li>';
@@ -440,7 +475,8 @@
 	}
 
 	function askEndpointForQuestion(question) {
-		return ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+		var endpoint = ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+		return isZh ? endpoint : endpoint + '?lang=en';
 	}
 
 	function parseRetryAfter(response) {
@@ -450,9 +486,9 @@
 
 	function runAsk(question) {
 		var query = (question || '').trim();
-		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0) return;
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return;
 		if (query.length > 100) {
-			renderAskAnswer('', false, '問題太長，請縮短到 100 字以內。');
+			renderAskAnswer('', false, askT.questionTooLong);
 			return;
 		}
 
@@ -472,7 +508,7 @@
 				return response.text().then(function (text) {
 					var retryAfter = parseRetryAfter(response);
 					if (response.status === 429 && retryAfter > 0) startAskCooldown(retryAfter);
-					throw new Error(text || '提問服務暫時無法使用，請稍後再試。');
+					throw new Error(text || askT.fetchError);
 				});
 			}
 
@@ -502,7 +538,7 @@
 			return readNext();
 		}).catch(function (error) {
 			if (error && error.name === 'AbortError') return;
-			renderAskAnswer('', false, error && error.message ? error.message : '連線發生錯誤，請稍後再試。');
+			renderAskAnswer('', false, error && error.message ? error.message : askT.networkError);
 		}).finally(function () {
 			setAskLoading(false);
 			askAbortController = null;
@@ -510,7 +546,7 @@
 	}
 
 	function initAsk() {
-		if (!askPanel || !askSubmit || !askAnswer || !window.fetch) return;
+		if (!askSubmit || !askAnswer || !window.fetch) return;
 
 		fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
 			if (!response.ok) throw new Error('capacity unavailable');
@@ -518,7 +554,8 @@
 		}).then(function (data) {
 			if (!data || data.status !== 'available') return;
 			askAvailable = true;
-			askPanel.hidden = false;
+			if (askPanel) askPanel.hidden = false;
+			askSubmit.hidden = false;
 			updateAskControls();
 		}).catch(function () {
 			askAvailable = false;
@@ -528,6 +565,13 @@
 			runAsk(input.value);
 		});
 
+		if (askConsent) {
+			askConsent.addEventListener('change', function () {
+				updateAskControls();
+			});
+		}
+
+		if (!askPanel) return;
 		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
 		for (var i = 0; i < samples.length; i++) {
 			samples[i].addEventListener('click', function (event) {

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -9,6 +9,8 @@
 	var askSubmit = document.getElementById('sayit-ask-submit');
 		var askStatus = document.getElementById('sayit-ask-status');
 	var askAnswer = document.getElementById('sayit-ask-answer');
+	var lastAskMarkdown = '';
+	var askCopyResetTimer = null;
 	if (!input) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
@@ -21,6 +23,9 @@
 			cooldown: function (seconds) { return '💬 ' + seconds + ' 秒後可再提問'; },
 			searching: '檢索逐字稿中…',
 			sourcesHeading: '出處',
+			copyMarkdown: '複製 Markdown',
+			copiedMarkdown: '已複製',
+			copyFailed: '無法複製，請手動選取文字',
 			questionTooLong: '問題太長，請縮短到 100 字以內。',
 			fetchError: '提問服務暫時無法使用，請稍後再試。',
 			networkError: '連線發生錯誤，請稍後再試。',
@@ -34,6 +39,9 @@
 			cooldown: function (seconds) { return '💬 Ask again in ' + seconds + ' s'; },
 			searching: 'Searching the transcripts…',
 			sourcesHeading: 'Sources',
+			copyMarkdown: 'Copy Markdown',
+			copiedMarkdown: 'Copied',
+			copyFailed: 'Could not copy. Select the answer and copy manually.',
 			questionTooLong: 'Your question is too long. Please shorten it to 100 characters or fewer.',
 			fetchError: 'The ask service is temporarily unavailable. Please try again later.',
 			networkError: 'Connection error. Please try again later.',
@@ -169,6 +177,55 @@
 		return doc.body.innerHTML;
 	}
 
+
+	function askHasVisibleAnswer() {
+		return !!(askAnswer && !askAnswer.hidden && (lastAskMarkdown || '').trim());
+	}
+
+	function copyMarkdownText(text) {
+		if (!text) return Promise.resolve(false);
+		try {
+			if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+				return navigator.clipboard.writeText(text).then(function () { return true; }).catch(function () { return false; });
+			}
+		} catch (e) {}
+		try {
+			var textarea = document.createElement('textarea');
+			textarea.value = text;
+			textarea.setAttribute('readonly', '');
+			textarea.style.position = 'fixed';
+			textarea.style.inset = '0 auto auto 0';
+			textarea.style.opacity = '0';
+			document.body.appendChild(textarea);
+			textarea.focus();
+			textarea.select();
+			var ok = document.execCommand('copy');
+			textarea.remove();
+			return Promise.resolve(!!ok);
+		} catch (err) {
+			return Promise.resolve(false);
+		}
+	}
+
+	function bindAskCopyButton() {
+		if (!askAnswer || askAnswer.dataset.sayitCopyBound) return;
+		askAnswer.dataset.sayitCopyBound = '1';
+		askAnswer.addEventListener('click', function (e) {
+			var btn = e.target && e.target.closest ? e.target.closest('[data-sayit-ask-copy]') : null;
+			if (!btn || btn.disabled) return;
+			var text = lastAskMarkdown || '';
+			if (!text.trim()) return;
+			copyMarkdownText(text).then(function (ok) {
+				btn.textContent = ok ? askT.copiedMarkdown : askT.copyFailed;
+				if (askCopyResetTimer) clearTimeout(askCopyResetTimer);
+				askCopyResetTimer = setTimeout(function () {
+					btn.textContent = askT.copyMarkdown;
+					askCopyResetTimer = null;
+				}, 2000);
+			});
+		});
+	}
+
 	function parseAskAnswer(raw) {
 		var sources = [];
 		var seen = {};
@@ -221,6 +278,7 @@
 		if (!askAnswer) return;
 		askAnswer.hidden = true;
 		askAnswer.innerHTML = '';
+		lastAskMarkdown = '';
 	}
 
 	function setAskStatus(message) {
@@ -269,14 +327,20 @@
 
 	function renderAskAnswer(raw, loading, error) {
 		if (!askAnswer) return;
+		bindAskCopyButton();
 		askAnswer.hidden = false;
 		if (error) {
+			lastAskMarkdown = '';
 			askAnswer.innerHTML = '<p class="homepage-ask-answer__error">' + sanitizeHtml(escapeHtml(error)) + '</p>';
 			return;
 		}
 
+		lastAskMarkdown = raw || '';
 		var parsed = parseAskAnswer(raw);
 		var html = '';
+		if ((raw || '').trim()) {
+			html += '<div class="homepage-ask-answer__toolbar"><button type="button" class="homepage-ask-answer__copy" data-sayit-ask-copy aria-label="' + escapeHtml(askT.copyMarkdown) + '">' + escapeHtml(askT.copyMarkdown) + '</button></div>';
+		}
 		if (!parsed.html && loading) {
 			html += '<p class="homepage-ask-answer__status">' + escapeHtml(askT.searching) + '</p>';
 		}
@@ -476,7 +540,8 @@
 			}
 
 			if (!msg.results || msg.results.length === 0) {
-				renderNoResults(query);
+				if (!askHasVisibleAnswer()) renderNoResults(query);
+				else hideResults();
 				return;
 			}
 

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -5,6 +5,10 @@
 	var results = document.getElementById('sayit-search-results');
 	var shortcutBadge = document.getElementById('sayit-search-shortcut');
 	var speechList = document.getElementById('sayit-speech-list');
+	var askPanel = document.getElementById('sayit-ask');
+	var askSubmit = document.getElementById('sayit-ask-submit');
+	var askStatus = document.getElementById('sayit-ask-status');
+	var askAnswer = document.getElementById('sayit-ask-answer');
 	if (!input || !results) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
@@ -20,6 +24,12 @@
 	var requestId = 0;
 	var pendingResolves = {};
 	var workerWarmed = false;
+	var askAvailable = false;
+	var askLoading = false;
+	var askCooldownTimer = null;
+	var askCooldownRemaining = 0;
+	var askAbortController = null;
+	var ASK_BASE_URL = 'https://ask.archive.tw';
 
 	function shouldWarmupOnFocus() {
 		var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
@@ -73,6 +83,79 @@
 		return textarea.value;
 	}
 
+	function isSafeHttpUrl(value) {
+		if (/[\s"'<>]/.test(value) || /&(quot|#39|lt|gt);/i.test(value)) return false;
+		try {
+			var url = new URL(value);
+			return url.protocol === 'http:' || url.protocol === 'https:';
+		} catch (e) {
+			return false;
+		}
+	}
+
+	function sanitizeHtml(html) {
+		var doc = new DOMParser().parseFromString(html, 'text/html');
+		var blocked = doc.body.querySelectorAll('script, iframe, object, embed, base, meta, link');
+		for (var i = 0; i < blocked.length; i++) blocked[i].remove();
+
+		var walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
+		var element = walker.nextNode();
+		while (element) {
+			var attrs = Array.prototype.slice.call(element.attributes);
+			for (var j = 0; j < attrs.length; j++) {
+				var attr = attrs[j];
+				var name = attr.name.toLowerCase();
+				if (name.indexOf('on') === 0 || name === 'srcdoc' || name === 'style') {
+					element.removeAttribute(attr.name);
+					continue;
+				}
+				if (/^(href|src|xlink:href|action|formaction|poster)$/i.test(name) && !isSafeHttpUrl(attr.value)) {
+					element.removeAttribute(attr.name);
+				}
+			}
+			if (element.tagName.toLowerCase() === 'a') {
+				element.setAttribute('target', '_blank');
+				element.setAttribute('rel', 'nofollow noopener noreferrer');
+			}
+			element = walker.nextNode();
+		}
+
+		return doc.body.innerHTML;
+	}
+
+	function parseAskAnswer(raw) {
+		var sources = [];
+		var seen = {};
+		var body = (raw || '').replace(/^\[\^(\d+)\]:\s*\[([^\]]*)\]\(([^)\s]+)\)\s*$/gm, function (_m, num, label, href) {
+			if (!isSafeHttpUrl(href)) return '';
+			var index = Number(num);
+			if (!seen[index]) {
+				seen[index] = true;
+				sources.push({ index: index, label: label.trim() || href, href: href });
+			}
+			return '';
+		}).trim();
+		sources.sort(function (a, b) { return a.index - b.index; });
+
+		var hrefByIndex = {};
+		for (var i = 0; i < sources.length; i++) hrefByIndex[sources[i].index] = sources[i].href;
+
+		var html = escapeHtml(body);
+		html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+		html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+		html = html.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, function (_m, label, href) {
+			if (!isSafeHttpUrl(href)) return escapeHtml(label);
+			return '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(label) + '</a>';
+		});
+		html = html.replace(/\[\^(\d+)\]/g, function (m, num) {
+			var href = hrefByIndex[Number(num)];
+			if (!href) return '';
+			return '<sup class="cite"><a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">[' + escapeHtml(num) + ']</a></sup>';
+		});
+
+		return { html: sanitizeHtml(html), sources: sources };
+	}
+
 	function showResults() {
 		results.hidden = false;
 		if (speechList) speechList.style.display = 'none';
@@ -84,6 +167,80 @@
 		if (speechList) speechList.style.display = '';
 		currentSearchResults = null;
 		displayedCount = 0;
+	}
+
+	function hideAskAnswer() {
+		if (!askAnswer) return;
+		askAnswer.hidden = true;
+		askAnswer.innerHTML = '';
+	}
+
+	function setAskStatus(message) {
+		if (askStatus) askStatus.textContent = message || '';
+	}
+
+	function updateAskControls() {
+		if (!askPanel || !askSubmit) return;
+		var hasQuestion = Boolean(input.value.trim());
+		var disabled = askLoading || askCooldownRemaining > 0;
+		askSubmit.disabled = disabled || !hasQuestion;
+		askSubmit.textContent = askLoading
+			? '💬 提問中…'
+			: (askCooldownRemaining > 0 ? '💬 ' + askCooldownRemaining + ' 秒後可再提問' : '💬 提問');
+
+		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
+		for (var i = 0; i < samples.length; i++) {
+			samples[i].disabled = disabled;
+		}
+	}
+
+	function startAskCooldown(seconds) {
+		askCooldownRemaining = Math.max(0, Number(seconds) || 0);
+		if (askCooldownTimer) clearInterval(askCooldownTimer);
+		if (askCooldownRemaining <= 0) {
+			updateAskControls();
+			return;
+		}
+		updateAskControls();
+		askCooldownTimer = setInterval(function () {
+			askCooldownRemaining -= 1;
+			if (askCooldownRemaining <= 0) {
+				askCooldownRemaining = 0;
+				clearInterval(askCooldownTimer);
+				askCooldownTimer = null;
+			}
+			updateAskControls();
+		}, 1000);
+	}
+
+	function renderAskAnswer(raw, loading, error) {
+		if (!askAnswer) return;
+		askAnswer.hidden = false;
+		if (error) {
+			askAnswer.innerHTML = '<p class="homepage-ask-answer__error">' + sanitizeHtml(escapeHtml(error)) + '</p>';
+			return;
+		}
+
+		var parsed = parseAskAnswer(raw);
+		var html = '';
+		if (!parsed.html && loading) {
+			html += '<p class="homepage-ask-answer__status">檢索逐字稿中…</p>';
+		}
+		if (parsed.html) {
+			html += '<div class="homepage-ask-answer__body">' + parsed.html + '</div>';
+		}
+		if (loading) {
+			html += '<span class="homepage-ask-answer__cursor" aria-hidden="true">▌</span>';
+		}
+		if (parsed.sources.length > 0) {
+			html += '<div class="homepage-ask-answer__sources"><h3>出處</h3><ol>';
+			for (var i = 0; i < parsed.sources.length; i++) {
+				var source = parsed.sources[i];
+				html += '<li value="' + source.index + '"><a href="' + escapeHtml(source.href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(source.label) + '</a></li>';
+			}
+			html += '</ol></div>';
+		}
+		askAnswer.innerHTML = html;
 	}
 
 	function renderLoading() {
@@ -247,6 +404,7 @@
 			return;
 		}
 
+		hideAskAnswer();
 		currentQuery = query;
 		currentSearchResults = null;
 		displayedCount = 0;
@@ -276,11 +434,116 @@
 		});
 	}
 
+	function setAskLoading(value) {
+		askLoading = value;
+		updateAskControls();
+	}
+
+	function askEndpointForQuestion(question) {
+		return ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+	}
+
+	function parseRetryAfter(response) {
+		var retryAfter = Number(response.headers.get('Retry-After'));
+		return Number.isFinite(retryAfter) && retryAfter > 0 ? Math.ceil(retryAfter) : 0;
+	}
+
+	function runAsk(question) {
+		var query = (question || '').trim();
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0) return;
+		if (query.length > 100) {
+			renderAskAnswer('', false, '問題太長，請縮短到 100 字以內。');
+			return;
+		}
+
+		input.value = query;
+		currentQuery = '';
+		clearTimeout(debounceTimer);
+		hideResults();
+		setAskStatus('');
+		renderAskAnswer('', true, '');
+		setAskLoading(true);
+
+		if (askAbortController) askAbortController.abort();
+		askAbortController = new AbortController();
+
+		fetch(askEndpointForQuestion(query), { signal: askAbortController.signal }).then(function (response) {
+			if (!response.ok) {
+				return response.text().then(function (text) {
+					var retryAfter = parseRetryAfter(response);
+					if (response.status === 429 && retryAfter > 0) startAskCooldown(retryAfter);
+					throw new Error(text || '提問服務暫時無法使用，請稍後再試。');
+				});
+			}
+
+			if (!response.body || !response.body.getReader) {
+				return response.text().then(function (text) {
+					renderAskAnswer(text, false, '');
+				});
+			}
+
+			var reader = response.body.getReader();
+			var decoder = new TextDecoder();
+			var raw = '';
+
+			function readNext() {
+				return reader.read().then(function (chunk) {
+					if (chunk.done) {
+						raw += decoder.decode();
+						renderAskAnswer(raw, false, '');
+						return;
+					}
+					raw += decoder.decode(chunk.value, { stream: true });
+					renderAskAnswer(raw, true, '');
+					return readNext();
+				});
+			}
+
+			return readNext();
+		}).catch(function (error) {
+			if (error && error.name === 'AbortError') return;
+			renderAskAnswer('', false, error && error.message ? error.message : '連線發生錯誤，請稍後再試。');
+		}).finally(function () {
+			setAskLoading(false);
+			askAbortController = null;
+		});
+	}
+
+	function initAsk() {
+		if (!askPanel || !askSubmit || !askAnswer || !window.fetch) return;
+
+		fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
+			if (!response.ok) throw new Error('capacity unavailable');
+			return response.json();
+		}).then(function (data) {
+			if (!data || data.status !== 'available') return;
+			askAvailable = true;
+			askPanel.hidden = false;
+			updateAskControls();
+		}).catch(function () {
+			askAvailable = false;
+		});
+
+		askSubmit.addEventListener('click', function () {
+			runAsk(input.value);
+		});
+
+		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
+		for (var i = 0; i < samples.length; i++) {
+			samples[i].addEventListener('click', function (event) {
+				var question = event.currentTarget.getAttribute('data-sayit-ask-question') || '';
+				runAsk(question);
+			});
+		}
+	}
+
 	input.addEventListener('input', function () {
 		clearTimeout(debounceTimer);
 		var query = input.value;
+		updateAskControls();
 		if (!query.trim()) {
 			hideResults();
+			hideAskAnswer();
 			currentQuery = '';
 			return;
 		}
@@ -294,8 +557,10 @@
 			input.value = '';
 			input.blur();
 			hideResults();
+			hideAskAnswer();
 			currentQuery = '';
 			clearTimeout(debounceTimer);
+			updateAskControls();
 		}
 	});
 
@@ -318,4 +583,6 @@
 	input.addEventListener('blur', function () {
 		if (shortcutBadge && !input.value) shortcutBadge.style.opacity = '1';
 	});
+
+	initAsk();
 })();

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -25,6 +25,7 @@
 			questionTooLong: '問題太長，請縮短到 100 字以內。',
 			fetchError: '提問服務暫時無法使用，請稍後再試。',
 			networkError: '連線發生錯誤，請稍後再試。',
+			consentRequired: '請先同意隱私權政策和使用條款，再按 Enter 提問；一般搜尋結果仍會顯示。',
 		},
 		en: {
 			searchPlaceholder: 'Search speeches…',
@@ -37,6 +38,7 @@
 			questionTooLong: 'Your question is too long. Please shorten it to 100 characters or fewer.',
 			fetchError: 'The ask service is temporarily unavailable. Please try again later.',
 			networkError: 'Connection error. Please try again later.',
+			consentRequired: 'Please agree to the Privacy Policy and Terms of Use first to ask AI; regular search results will still show.',
 		},
 	};
 	var askT = ASK_STRINGS[isZh ? 'zh' : 'en'];
@@ -439,7 +441,6 @@
 			return;
 		}
 
-		hideAskAnswer();
 		currentQuery = query;
 		currentSearchResults = null;
 		displayedCount = 0;
@@ -486,10 +487,10 @@
 
 	function runAsk(question) {
 		var query = (question || '').trim();
-		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return;
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return Promise.resolve();
 		if (query.length > 100) {
 			renderAskAnswer('', false, askT.questionTooLong);
-			return;
+			return Promise.resolve();
 		}
 
 		input.value = query;
@@ -503,7 +504,7 @@
 		if (askAbortController) askAbortController.abort();
 		askAbortController = new AbortController();
 
-		fetch(askEndpointForQuestion(query), { signal: askAbortController.signal }).then(function (response) {
+		return fetch(askEndpointForQuestion(query), { signal: askAbortController.signal }).then(function (response) {
 			if (!response.ok) {
 				return response.text().then(function (text) {
 					var retryAfter = parseRetryAfter(response);
@@ -546,9 +547,9 @@
 	}
 
 	function initAsk() {
-		if (!askSubmit || !askAnswer || !window.fetch) return;
+		if (!askSubmit || !askAnswer || !window.fetch) return Promise.resolve();
 
-		fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
+		var capacityPromise = fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
 			if (!response.ok) throw new Error('capacity unavailable');
 			return response.json();
 		}).then(function (data) {
@@ -562,7 +563,7 @@
 		});
 
 		askSubmit.addEventListener('click', function () {
-			runAsk(input.value);
+			submitSearch(input.value);
 		});
 
 		if (askConsent) {
@@ -571,14 +572,46 @@
 			});
 		}
 
-		if (!askPanel) return;
-		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
-		for (var i = 0; i < samples.length; i++) {
-			samples[i].addEventListener('click', function (event) {
-				var question = event.currentTarget.getAttribute('data-sayit-ask-question') || '';
-				runAsk(question);
-			});
+		if (askPanel) {
+			var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
+			for (var i = 0; i < samples.length; i++) {
+				samples[i].addEventListener('click', function (event) {
+					var question = event.currentTarget.getAttribute('data-sayit-ask-question') || '';
+					submitSearch(question);
+				});
+			}
 		}
+
+		return capacityPromise;
+	}
+
+	function submitSearch(query) {
+		var q = (query || '').trim();
+		if (!q) return;
+
+		var onSearchResults = window.location.pathname === '/search/';
+
+		if (askAnswer && askAvailable && consentAccepted() && q.length <= 100 && !askLoading && askCooldownRemaining <= 0) {
+			runAiFirstSearch(q, onSearchResults);
+			return;
+		}
+
+		if (askAnswer) {
+			if (askAvailable && !consentAccepted() && q.length <= 100) setAskStatus(askT.consentRequired);
+			if (onSearchResults) return;
+			hideAskAnswer();
+			doSearch(q);
+			return;
+		}
+
+		window.location.assign('/search/?q=' + encodeURIComponent(query));
+	}
+
+	function runAiFirstSearch(query, skipRegularResults) {
+		hideResults();
+		return runAsk(query).then(function () {
+			if (!skipRegularResults) doSearch(query);
+		});
 	}
 
 	input.addEventListener('input', function () {
@@ -591,12 +624,16 @@
 			currentQuery = '';
 			return;
 		}
-		debounceTimer = setTimeout(function () {
-			doSearch(query);
-		}, 250);
 	});
 
 	input.addEventListener('keydown', function (e) {
+		if (e.key === 'Enter') {
+			if (e.isComposing || e.keyCode === 229) return;
+			if (e.metaKey || e.ctrlKey || e.altKey) return;
+			e.preventDefault();
+			submitSearch(input.value);
+			return;
+		}
 		if (e.key === 'Escape') {
 			input.value = '';
 			input.blur();
@@ -628,5 +665,12 @@
 		if (shortcutBadge && !input.value) shortcutBadge.style.opacity = '1';
 	});
 
-	initAsk();
+	initAsk().finally(function () {
+		if (!results || window.location.pathname !== '/search/') return;
+		var initialQuery = new URLSearchParams(window.location.search).get('q') || '';
+		if (!initialQuery.trim()) return;
+		input.value = initialQuery;
+		updateAskControls();
+		submitSearch(initialQuery);
+	});
 })();

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -475,7 +475,7 @@
 	}
 
 	function askEndpointForQuestion(question) {
-		var endpoint = ASK_BASE_URL + '/cag/' + encodeURIComponent(question);
+		var endpoint = ASK_BASE_URL + '/au/' + encodeURIComponent(question);
 		return isZh ? endpoint : endpoint + '?lang=en';
 	}
 

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -7,10 +7,9 @@
 	var speechList = document.getElementById('sayit-speech-list');
 	var askPanel = document.getElementById('sayit-ask');
 	var askSubmit = document.getElementById('sayit-ask-submit');
-	var askConsent = document.getElementById('sayit-ask-consent');
-	var askStatus = document.getElementById('sayit-ask-status');
+		var askStatus = document.getElementById('sayit-ask-status');
 	var askAnswer = document.getElementById('sayit-ask-answer');
-	if (!input || !results) return;
+	if (!input) return;
 
 	var isZh = document.documentElement.classList.contains('lang-zh');
 	var ASK_STRINGS = {
@@ -187,11 +186,13 @@
 	}
 
 	function showResults() {
+		if (!results) return;
 		results.hidden = false;
 		if (speechList) speechList.style.display = 'none';
 	}
 
 	function hideResults() {
+		if (!results) return;
 		results.hidden = true;
 		results.innerHTML = '';
 		if (speechList) speechList.style.display = '';
@@ -210,7 +211,7 @@
 	}
 
 	function consentAccepted() {
-		return askConsent ? askConsent.checked : false;
+		return true;
 	}
 
 	function updateAskControls() {
@@ -222,7 +223,6 @@
 		askSubmit.textContent = askLoading
 			? askT.submitting
 			: (askCooldownRemaining > 0 ? askT.cooldown(askCooldownRemaining) : askT.submit);
-		if (askConsent) askConsent.disabled = askLoading;
 
 		if (!askPanel) return;
 		var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
@@ -436,6 +436,7 @@
 	}
 
 	function doSearch(query) {
+		if (!results) return;
 		if (!query.trim()) {
 			hideResults();
 			return;
@@ -487,7 +488,7 @@
 
 	function runAsk(question) {
 		var query = (question || '').trim();
-		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0 || !consentAccepted()) return Promise.resolve();
+		if (!askAvailable || !query || askLoading || askCooldownRemaining > 0) return Promise.resolve();
 		if (query.length > 100) {
 			renderAskAnswer('', false, askT.questionTooLong);
 			return Promise.resolve();
@@ -547,7 +548,7 @@
 	}
 
 	function initAsk() {
-		if (!askSubmit || !askAnswer || !window.fetch) return Promise.resolve();
+		if (!askAnswer || !window.fetch) return Promise.resolve();
 
 		var capacityPromise = fetch(ASK_BASE_URL + '/capacity', { headers: { Accept: 'application/json' } }).then(function (response) {
 			if (!response.ok) throw new Error('capacity unavailable');
@@ -556,21 +557,10 @@
 			if (!data || data.status !== 'available') return;
 			askAvailable = true;
 			if (askPanel) askPanel.hidden = false;
-			askSubmit.hidden = false;
 			updateAskControls();
 		}).catch(function () {
 			askAvailable = false;
 		});
-
-		askSubmit.addEventListener('click', function () {
-			submitSearch(input.value);
-		});
-
-		if (askConsent) {
-			askConsent.addEventListener('change', function () {
-				updateAskControls();
-			});
-		}
 
 		if (askPanel) {
 			var samples = askPanel.querySelectorAll('[data-sayit-ask-question]');
@@ -591,20 +581,21 @@
 
 		var onSearchResults = window.location.pathname === '/search/';
 
-		if (askAnswer && askAvailable && consentAccepted() && q.length <= 100 && !askLoading && askCooldownRemaining <= 0) {
+		if (askAnswer && askAvailable && q.length <= 100 && !askLoading && askCooldownRemaining <= 0) {
 			runAiFirstSearch(q, onSearchResults);
 			return;
 		}
 
 		if (askAnswer) {
-			if (askAvailable && !consentAccepted() && q.length <= 100) setAskStatus(askT.consentRequired);
 			if (onSearchResults) return;
 			hideAskAnswer();
 			doSearch(q);
 			return;
 		}
 
-		window.location.assign('/search/?q=' + encodeURIComponent(query));
+		if (!results) return;
+		hideAskAnswer();
+		doSearch(q);
 	}
 
 	function runAiFirstSearch(query, skipRegularResults) {


### PR DESCRIPTION
## Scope (本PR由Claude Opus 4.8 撰寫)

將 CAG（ask.archive.tw）串流提問功能整合進 SayIt 首頁，與既有的搜尋框合並呈現。本分支共 4 個 commit。

## 變更內容

- **首頁 Ask UI**（`src/views/HomeView.vue`）
  - 在搜尋框旁加入「提問」按鈕，搜尋框與按鈕改為 `homepage-search__row` 並排佈局（窄螢幕自動改為直向堆疊）。
  - 新增 Ask 介紹文字、隱私／使用條款核取方塊（consent checkbox），未勾選同意前不可提問。
  - 新增 `#sayit-ask-answer` 區塊，串流回答呈現在同一頁（含 loading cursor、引用來源清單樣式）。
  - 全面雙語化（`lang="zh"` / `lang="en"`），並補上 dark mode 樣式。
  - 範例問句（sample questions）目前以註解保留，尚未啟用。

- **前端互動邏輯**（`public/static/speeches/js/pagefind-search.js`、同步至 `www/`）
  - 啟動時查詢 `GET https://ask.archive.tw/capacity`，回報 `available` 時才顯示 Ask UI。
  - 處理 consent 勾選、提問送出、串流回答接收與渲染、提問冷卻（cooldown）倒數、錯誤訊息。
  - 內含 `isSafeHttpUrl` / `sanitizeHtml` 等防護，回答中的引用連結與 `[^n]` 註腳會被解析為來源清單。

- **測試**（`test/render.spec.ts`）
  - 新增 SSR 測試，驗證首頁 Ask UI 預設為 `hidden`、consent 與 submit 元素、雙語隱私／條款連結皆正確渲染。

## 排版調整

- 將「我已閱讀並同意…」consent 移到搜尋框與提問按鈕上方。
- 修訂整體排版與間距。

## 備註

cc @audreyt — 這是 `feat/cag` 分支的首頁實驗成果，麻煩看一下整合方向。

Closes #137
Work on #135（#135 第 1 項「首頁搜尋框 Ask 整合」完成；搜尋頁、對話頁、講者頁仍待研究）
