### PR TITLE
fix(cache): isolate speech tag purge from pathPrefixes

### DIFF
--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -157,12 +157,28 @@ export type PurgeOptions =
 /**
  * Purge front-of-Worker Workers Cache.
  * pathPrefixes are true prefixes — never pass '/' for "home only"; use tags for exact list pages.
+ * Prefer tags-only or pathPrefixes-only calls; combining is allowed but a bad prefix must not
+ * block tags — callers should split when prefixes may be untrusted.
  */
 export async function purgeWorkersCache(options: PurgeOptions): Promise<void> {
 	try {
 		console.log('[workers cache] purging', options);
-		await cache.purge(options);
+		const result = await cache.purge(options);
+		console.log('[workers cache] purge result', result);
+		if (result && typeof result === 'object' && 'success' in result && result.success === false) {
+			console.error('[workers cache] purge reported failure', result);
+		}
 	} catch (err) {
 		console.error('[workers cache] purge error', err);
 	}
+}
+
+/** Canonical request path for a speech filename (percent-encoded; no raw Unicode). */
+export function speechRequestPath(filename: string): string {
+	return `/${encodeURIComponent(filename)}`;
+}
+
+/** Canonical request path for a speaker route. */
+export function speakerRequestPath(routePathname: string): string {
+	return `/speaker/${encodeURIComponent(routePathname)}`;
 }

--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -11,6 +11,8 @@ import {
 	r2MdKey,
 	r2OgSectionKey,
 	r2OgSpeechKey,
+	speechRequestPath,
+	speakerRequestPath,
 	tags
 } from './cache';
 import {
@@ -541,8 +543,9 @@ async function invalidateSpeechCaches(c: Context<ApiEnv>, filename: string) {
 		`${CACHE_KEY_VERSION}/${host}/${encodedFilename}`,
 		r2OgSpeechKey(filename),
 	];
-	// pathPrefixes only for intentional breadth (speech body + sections). List roots use tags only.
-	const pathPrefixes = [`/${filename}`, `/${encodedFilename}`];
+	// pathPrefixes: request-path encoding only (percent-encoded). Raw Unicode prefixes can fail purge.
+	// List roots use tags only — never pathPrefix '/'.
+	const pathPrefixes = [speechRequestPath(filename)];
 
 	try {
 		const result = await c.env.DB.prepare(
@@ -557,12 +560,12 @@ async function invalidateSpeechCaches(c: Context<ApiEnv>, filename: string) {
 		console.error('[invalidate] section query error', err);
 	}
 
+	const purgeTags = [tags.speech(filename), tags.listHome, tags.listSpeeches, tags.listRss];
+	// Split tags vs pathPrefixes so a bad prefix cannot block tag purge.
 	await Promise.allSettled([
 		...r2Keys.map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)),
-		purgeWorkersCache({
-			tags: [tags.speech(filename), tags.listHome, tags.listSpeeches, tags.listRss],
-			pathPrefixes,
-		}),
+		purgeWorkersCache({ tags: purgeTags }),
+		purgeWorkersCache({ pathPrefixes }),
 	]);
 }
 
@@ -575,8 +578,8 @@ async function invalidateSpeakerCaches(c: Context<ApiEnv>, speakerRoutePathnames
 	for (const routePathname of speakerRoutePathnames) {
 		r2Keys.add(`${CACHE_KEY_VERSION}/${host}/speaker/${routePathname}`);
 		r2Keys.add(`${CACHE_KEY_VERSION}/${host}/speaker/${encodeURIComponent(routePathname)}`);
-		pathPrefixes.push(`/speaker/${routePathname}`);
-		pathPrefixes.push(`/speaker/${encodeURIComponent(routePathname)}`);
+		// Request path is percent-encoded; skip raw Unicode prefixes.
+		pathPrefixes.push(speakerRequestPath(routePathname));
 	}
 
 	const purgeTags = speakerRoutePathnames.map((p) => tags.speaker(p));
@@ -584,10 +587,8 @@ async function invalidateSpeakerCaches(c: Context<ApiEnv>, speakerRoutePathnames
 
 	await Promise.allSettled([
 		...Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)),
-		purgeWorkersCache({
-			tags: purgeTags,
-			...(pathPrefixes.length > 0 ? { pathPrefixes } : {}),
-		}),
+		purgeWorkersCache({ tags: purgeTags }),
+		...(pathPrefixes.length > 0 ? [purgeWorkersCache({ pathPrefixes })] : []),
 	]);
 }
 

--- a/test/cache_unit.spec.ts
+++ b/test/cache_unit.spec.ts
@@ -9,6 +9,8 @@ import {
 	r2OgSectionKey,
 	r2OgSpeechKey,
 	readR2Cache,
+	speechRequestPath,
+	speakerRequestPath,
 	tags,
 	writeR2Cache,
 	type PurgeOptions
@@ -147,5 +149,18 @@ describe('purgeWorkersCache option shape', () => {
 		expect(byTags).toBeTruthy();
 		expect(byPrefix).toBeTruthy();
 		expect(everything).toBeTruthy();
+	});
+});
+
+describe('speech/speaker request paths', () => {
+	it('percent-encodes CJK speech filenames for pathPrefixes', () => {
+		const filename = '2025-11-10-柏林自由會議-ai-的角色';
+		expect(speechRequestPath(filename)).toBe(`/${encodeURIComponent(filename)}`);
+		expect(speechRequestPath(filename)).not.toContain('柏');
+	});
+
+	it('percent-encodes speaker routes', () => {
+		expect(speakerRequestPath('audrey-tang')).toBe('/speaker/audrey-tang');
+		expect(speakerRequestPath('唐鳳')).toBe(`/speaker/${encodeURIComponent('唐鳳')}`);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the live speech-page front-cache purge gap found after PR #145.

After upload PATCH, list roots (`/`, `/speeches/`, `/rss.xml`) correctly MISS via tags, but the speech HTML URL stayed HIT. Root cause: one combined `purge({ tags, pathPrefixes })` included raw Unicode `/${filename}` for CJK speeches; that can make the whole call untrustworthy while list roots still clear later via tags-only `invalidateListPageCaches`.

## Changes

- Split purge into **tags-only** then **pathPrefixes-only** for speech/speaker invalidation
- pathPrefixes use percent-encoded request paths only (`speechRequestPath` / `speakerRequestPath`)
- Log `cache.purge` result success/failure
- Unit tests for CJK path encoding helpers

Closes #146.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test` (451 pass)
- [x] Deploy + live: warm speech HIT → same-content PATCH → speech MISS (v-cc360a3 / v-42fdcb8)
