### PR TITLE
fix(cache): do not double-encode speaker route pathPrefixes

### DIFF
--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -178,7 +178,12 @@ export function speechRequestPath(filename: string): string {
 	return `/${encodeURIComponent(filename)}`;
 }
 
-/** Canonical request path for a speaker route. */
+/**
+ * Canonical request path for a speaker route.
+ * `routePathname` is already the stored/normalized route key (often percent-encoded);
+ * do not encodeURIComponent again.
+ */
 export function speakerRequestPath(routePathname: string): string {
-	return `/speaker/${encodeURIComponent(routePathname)}`;
+	const key = routePathname.startsWith('/') ? routePathname.slice(1) : routePathname;
+	return `/speaker/${key}`;
 }

--- a/test/cache_unit.spec.ts
+++ b/test/cache_unit.spec.ts
@@ -159,8 +159,11 @@ describe('speech/speaker request paths', () => {
 		expect(speechRequestPath(filename)).not.toContain('柏');
 	});
 
-	it('percent-encodes speaker routes', () => {
+	it('uses stored speaker route keys without double-encoding', () => {
 		expect(speakerRequestPath('audrey-tang')).toBe('/speaker/audrey-tang');
-		expect(speakerRequestPath('唐鳳')).toBe(`/speaker/${encodeURIComponent('唐鳳')}`);
+		const encoded = encodeURIComponent('唐鳳-3');
+		expect(speakerRequestPath(encoded)).toBe(`/speaker/${encoded}`);
+		// already-encoded input must not gain another %25 layer
+		expect(speakerRequestPath(encoded)).not.toContain('%25');
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up to #147: `speakerRequestPath` was `encodeURIComponent`-ing route pathnames that upload already stores as encoded keys (`normalizeSpeakerName`). That produced `/speaker/%25…` prefixes which never match real request paths.

## Changes

- Treat speaker route key as already-canonical
- Unit test asserts no `%25` double-encoding

Closes #148.

## Test plan

- [x] `bun run test test/cache_unit.spec.ts`
- [x] Deploy from main after merge (live v-42fdcb8)
