### PR TITLE
fix(cache): purge deleted section IDs on PATCH/DELETE

### DIFF
--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -532,8 +532,15 @@ function withSectionLinks(sections: PatchAssignedSection[]): NormalizedSection[]
 }
 
 
-/** 演講內容或 .an/.md 更新後，刪除 R2 origin 並 purge Workers Cache */
-async function invalidateSpeechCaches(c: Context<ApiEnv>, filename: string) {
+/** 演講內容或 .an/.md 更新後，刪除 R2 origin 並 purge Workers Cache.
+ *  extraSectionIds: section IDs that may no longer exist in D1 (deleted/reassigned on PATCH/DELETE)
+ *  but still need R2 + Workers Cache purge for /speech/:id pages.
+ */
+async function invalidateSpeechCaches(
+	c: Context<ApiEnv>,
+	filename: string,
+	extraSectionIds: Iterable<number> = []
+) {
 	const host = new URL(c.req.url).host;
 	const encodedFilename = encodeURIComponent(filename);
 	const r2Keys = [
@@ -546,18 +553,26 @@ async function invalidateSpeechCaches(c: Context<ApiEnv>, filename: string) {
 	// pathPrefixes: request-path encoding only (percent-encoded). Raw Unicode prefixes can fail purge.
 	// List roots use tags only — never pathPrefix '/'.
 	const pathPrefixes = [speechRequestPath(filename)];
+	const sectionIds = new Set<number>();
+	for (const id of extraSectionIds) {
+		if (Number.isFinite(id)) sectionIds.add(Number(id));
+	}
 
 	try {
 		const result = await c.env.DB.prepare(
 			'SELECT section_id FROM speech_content WHERE filename = ?'
 		).bind(filename).all();
 		for (const row of result.results as Array<{ section_id: number }>) {
-			r2Keys.push(`${CACHE_KEY_VERSION}/${host}/speech/${row.section_id}`);
-			r2Keys.push(r2OgSectionKey(row.section_id));
-			pathPrefixes.push(`/speech/${row.section_id}`);
+			sectionIds.add(Number(row.section_id));
 		}
 	} catch (err) {
 		console.error('[invalidate] section query error', err);
+	}
+
+	for (const sectionId of sectionIds) {
+		r2Keys.push(`${CACHE_KEY_VERSION}/${host}/speech/${sectionId}`);
+		r2Keys.push(r2OgSectionKey(sectionId));
+		pathPrefixes.push(`/speech/${sectionId}`);
 	}
 
 	const purgeTags = [tags.speech(filename), tags.listHome, tags.listSpeeches, tags.listRss];
@@ -700,7 +715,7 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				filename = canonicalFilename;
 			}
 
-			// 先查講者清單，再一次 batch 完成所有刪除 + 孤兒清理
+			// 先查講者與段落 ID（刪除後 invalidate 仍需清舊 /speech/:id 快取）
 				const linkedSpeakers = await withRetry(() => c.env.DB.prepare(
 					'SELECT speaker_route_pathname FROM speech_speakers WHERE speech_filename = ?'
 				)
@@ -709,6 +724,12 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				const speakerRoutePathnames = Array.from(
 					new Set((linkedSpeakers.results ?? []).map((row) => row.speaker_route_pathname).filter(Boolean))
 				);
+				const preexistingSectionRows = await withRetry(() => c.env.DB.prepare(
+					'SELECT section_id FROM speech_content WHERE filename = ?'
+				)
+					.bind(filename)
+					.all<{ section_id: number }>());
+				const preexistingSectionIds = (preexistingSectionRows.results ?? []).map((row) => Number(row.section_id));
 
 				// 單一 batch：刪段落 + 刪關聯 + 刪索引 + 清孤兒講者（減少 D1 round-trips）
 				console.log('[upload_markdown] DELETE batch for:', filename);
@@ -748,7 +769,7 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 					);
 				}
 
-				await invalidateSpeechCaches(c, filename);
+				await invalidateSpeechCaches(c, filename, preexistingSectionIds);
 				await invalidateSpeakerCaches(c, speakerRoutePathnames);
 				await invalidateListPageCaches(c, { home: true, speeches: true, speakers: true });
 				await syncSearchArtifactsAfterDelete(c, filename);
@@ -1234,8 +1255,9 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				await withRetry(() => c.env.DB.batch(cleanupBatch));
 			}
 
-			// 失效快取（R2，在 D1 交易之外）
-			await invalidateSpeechCaches(c, filename);
+			// 失效快取：含 PATCH 前的 section IDs（已刪除的 /speech/:id 仍需 purge）
+			const preexistingSectionIds = oldSections.map((section) => section.section_id);
+			await invalidateSpeechCaches(c, filename, preexistingSectionIds);
 			const affectedAlternateFilenames = Array.from(
 				new Set([currentAlternateFilename, desiredAlternateFilename].filter((value): value is string => Boolean(value && value !== filename)))
 			);

--- a/test/upload_markdown.spec.ts
+++ b/test/upload_markdown.spec.ts
@@ -364,3 +364,281 @@ describe('upload_markdown POST', () => {
 		expect(env.__putObjects.get('search-index-manifest.json')).toContain('"fresh-speech"');
 	});
 });
+
+
+describe('upload_markdown PATCH deletes stale section caches', () => {
+	it('purges deleted section R2 keys even when they are gone from D1', async () => {
+		const operations: Array<{ sql: string; args: unknown[] }> = [];
+		const deletedKeys: string[] = [];
+		let liveSections = [
+			{ section_id: 100, previous_section_id: null as number | null, next_section_id: 101 as number | null, section_speaker: null as string | null, section_content: '<p>Alpha</p>' },
+			{ section_id: 101, previous_section_id: 100 as number | null, next_section_id: null as number | null, section_speaker: null as string | null, section_content: '<p>Beta</p>' }
+		];
+
+		function query(sql: string, args: unknown[]) {
+			if (sql.includes('SELECT COUNT(*) AS count FROM speech_index')) {
+				return { success: true, results: [{ count: 1 }] };
+			}
+			if (sql.includes('SELECT COUNT(*) AS count FROM speakers')) {
+				return { success: true, results: [{ count: 0 }] };
+			}
+			if (sql.includes('SELECT COUNT(*) AS count FROM speech_content')) {
+				return { success: true, results: [{ count: liveSections.length }] };
+			}
+			if (sql.includes('FROM speech_index WHERE filename = ?')) {
+				return {
+					success: true,
+					results: [{
+						filename: 'demo-speech',
+						display_name: 'Demo Speech',
+						isNested: 0,
+						nest_filenames: '',
+						nest_display_names: '',
+						alternate_filename: null
+					}]
+				};
+			}
+			if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+				return { success: true, results: [{ next_id: 200 }] };
+			}
+			if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
+				return {
+					success: true,
+					results: liveSections.map((s) => ({
+						filename: 'demo-speech',
+						...s
+					}))
+				};
+			}
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
+				// Post-mutation view: only remaining rows (simulates D1 after DELETE)
+				return { success: true, results: liveSections.map(({ section_id }) => ({ section_id })) };
+			}
+			if (sql.includes('FROM speech_speakers')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT DISTINCT section_speaker')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('FROM speech_redirects')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename != ?')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('FROM speech_content sc') && sql.includes('LEFT JOIN speech_index')) {
+				return {
+					success: true,
+					results: liveSections.map((s) => ({
+						filename: 'demo-speech',
+						nest_filename: null,
+						section_id: s.section_id,
+						section_content: s.section_content,
+						display_name: 'Demo Speech',
+						name: null
+					}))
+				};
+			}
+			throw new Error(`Unexpected query: ${sql}`);
+		}
+
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'token-audrey',
+			BESTIAN_TRANSCRIPT_TOKEN: 'token-bestian',
+			ASSETS: { fetch: () => new Response('Not Found', { status: 404 }) },
+			SPEECH_CACHE: {
+				delete: async (key: string) => {
+					deletedKeys.push(key);
+					return true;
+				},
+				get: async () => null,
+				put: async () => {},
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: (sql: string) => {
+					const run = (args: unknown[] = []) => ({
+						sql,
+						args,
+						first: async () => {
+							if (sql.includes('section_id_counter') && sql.includes('RETURNING')) {
+								return { next_id: 200 };
+							}
+							const result = query(sql, args);
+							return result.results[0] ?? null;
+						},
+						all: async () => query(sql, args)
+					});
+					// Unbound prepare() must still carry sql for DB.batch([prepare(...)])
+					return Object.assign(run([]), {
+						bind: (...args: unknown[]) => run(args)
+					});
+				},
+				batch: async (statements: Array<{ sql?: string; args?: unknown[] }>) => {
+					for (const stmt of statements) {
+						if (typeof stmt?.sql !== 'string') continue;
+						operations.push({ sql: stmt.sql, args: stmt.args ?? [] });
+						const args = stmt.args ?? [];
+						if (stmt.sql.startsWith('DELETE FROM speech_content WHERE filename = ? AND section_id = ?')) {
+							const id = Number(args[1]);
+							liveSections = liveSections.filter((s) => s.section_id !== id);
+						}
+						if (stmt.sql.startsWith('UPDATE speech_content')) {
+							// bind(previous, next, speaker, content, filename, section_id)
+							const sectionId = Number(args[5]);
+							const content = String(args[3]);
+							const speaker = (args[2] as string | null) ?? null;
+							const prev = (args[0] as number | null) ?? null;
+							const next = (args[1] as number | null) ?? null;
+							liveSections = liveSections.map((s) =>
+								s.section_id === sectionId
+									? {
+											section_id: sectionId,
+											previous_section_id: prev,
+											next_section_id: next,
+											section_speaker: speaker,
+											section_content: content
+										}
+									: s
+							);
+						}
+						if (stmt.sql.startsWith('INSERT INTO speech_content')) {
+							liveSections.push({
+								section_id: Number(args[3]),
+								previous_section_id: (args[4] as number | null) ?? null,
+								next_section_id: (args[5] as number | null) ?? null,
+								section_speaker: (args[6] as string | null) ?? null,
+								section_content: String(args[7])
+							});
+						}
+					}
+					return statements.map(() => ({ meta: { changes: 1 } }));
+				}
+			},
+			__deletedKeys: deletedKeys
+		} as any;
+
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			// Keep only Alpha → section 101 must be deleted and purged
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha only'
+			})
+		});
+
+		expect(res.status).toBe(200);
+		const body = await res.json() as { deletedCount: number };
+		expect(body.deletedCount).toBe(1);
+		expect(deletedKeys).toEqual(
+			expect.arrayContaining([
+				`${CACHE_KEY_VERSION}/example.com/speech/101`,
+				`${CACHE_KEY_VERSION}/og/speech/101.png`,
+				// remaining section still purged too
+				`${CACHE_KEY_VERSION}/example.com/speech/100`,
+				`${CACHE_KEY_VERSION}/og/speech/100.png`
+			])
+		);
+		// Ensure we actually removed 101 from live D1 view before invalidate re-query
+		expect(liveSections.map((s) => s.section_id)).toEqual([100]);
+	});
+});
+
+describe('upload_markdown DELETE purges preexisting section caches', () => {
+	it('purges section R2 keys captured before speech_content rows are deleted', async () => {
+		const deletedKeys: string[] = [];
+		let liveSections = [
+			{ section_id: 42, previous_section_id: null as number | null, next_section_id: null as number | null, section_speaker: null as string | null, section_content: '<p>Only</p>' }
+		];
+		let speechExists = true;
+
+		function query(sql: string, args: unknown[]) {
+			if (sql.includes('FROM speech_redirects')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('FROM speech_speakers WHERE speech_filename = ?') || sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
+				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
+				return { success: true, results: liveSections.map(({ section_id }) => ({ section_id })) };
+			}
+			if (sql.includes('FROM speech_index WHERE filename = ?')) {
+				return {
+					success: true,
+					results: speechExists
+						? [{ filename: 'demo-speech', display_name: 'Demo', isNested: 0, nest_filenames: '', nest_display_names: '', alternate_filename: null }]
+						: []
+				};
+			}
+			throw new Error(`Unexpected query: ${sql}`);
+		}
+
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'token-audrey',
+			BESTIAN_TRANSCRIPT_TOKEN: 'token-bestian',
+			ASSETS: { fetch: () => new Response('Not Found', { status: 404 }) },
+			SPEECH_CACHE: {
+				delete: async (key: string) => {
+					deletedKeys.push(key);
+					return true;
+				},
+				get: async () => null,
+				put: async () => {},
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: (sql: string) => {
+					const run = (args: unknown[] = []) => ({
+						sql,
+						args,
+						first: async () => query(sql, args).results[0] ?? null,
+						all: async () => query(sql, args)
+					});
+					return Object.assign(run([]), {
+						bind: (...args: unknown[]) => run(args)
+					});
+				},
+				batch: async (statements: Array<{ sql?: string; args?: unknown[]; meta?: { changes: number } }>) => {
+					for (const stmt of statements) {
+						if (typeof stmt?.sql !== 'string') continue;
+						if (stmt.sql.startsWith('DELETE FROM speech_content WHERE filename = ?')) {
+							liveSections = [];
+						}
+						if (stmt.sql.startsWith('DELETE FROM speech_index WHERE filename = ?')) {
+							speechExists = false;
+						}
+					}
+					return statements.map((stmt) => {
+						const sql = stmt?.sql ?? '';
+						// Report real-looking change counts so DELETE does not 404
+						if (sql.startsWith('DELETE FROM speech_content')) return { meta: { changes: 1 } };
+						if (sql.startsWith('DELETE FROM speech_speakers')) return { meta: { changes: 0 } };
+						if (sql.startsWith('DELETE FROM speech_index')) return { meta: { changes: 1 } };
+						return { meta: { changes: 0 } };
+					});
+				}
+			}
+		} as any;
+
+		const { res } = await request('/api/upload_markdown?filename=demo-speech', env, {
+			method: 'DELETE',
+			headers: { Authorization: 'Bearer token-audrey' }
+		});
+		expect(res.status).toBe(200);
+		expect(deletedKeys).toEqual(
+			expect.arrayContaining([
+				`${CACHE_KEY_VERSION}/example.com/speech/42`,
+				`${CACHE_KEY_VERSION}/og/speech/42.png`,
+				`${CACHE_KEY_VERSION}/example.com/demo-speech`,
+				'an/demo-speech',
+				'md/demo-speech'
+			])
+		);
+		expect(liveSections).toEqual([]);
+	});
+});
+

--- a/test/upload_markdown_delete.spec.ts
+++ b/test/upload_markdown_delete.spec.ts
@@ -31,6 +31,11 @@ function createDeleteEnv(options: { speakerRoutes?: string[]; redirects?: Record
 			const target = redirects[String(args[0])];
 			return { success: true, results: target ? [{ new_filename: target }] : [] };
 		}
+		if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
+			// Prefetch before DELETE; values only matter for purge key coverage.
+			return { success: true, results: [{ section_id: 100 }, { section_id: 101 }] };
+		}
+
 		throw new Error(`Unexpected query: ${sql}`);
 	}
 


### PR DESCRIPTION
## Summary

When PATCH deletes/reassigns sections (or DELETE removes a speech), stale `/speech/:oldId` front + R2 + OG caches were not purged because `invalidateSpeechCaches` only re-queried **remaining** section IDs after D1 mutation.

## Changes

- `invalidateSpeechCaches(filename, extraSectionIds?)` unions preexisting IDs
- PATCH passes `oldSections.map(id)` before invalidation
- DELETE prefetches section IDs before the delete batch
- Regression tests for PATCH delete and DELETE

Closes #150.

## Test plan

- [x] `bun run typecheck`
- [x] upload_markdown / delete / patch specs
- [ ] Deploy from main