### PR TITLE
fix(upload): single-batch speakers + fail-visible cache purge

### DIFF
--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -159,19 +159,38 @@ export type PurgeOptions =
  * pathPrefixes are true prefixes — never pass '/' for "home only"; use tags for exact list pages.
  * Prefer tags-only or pathPrefixes-only calls; combining is allowed but a bad prefix must not
  * block tags — callers should split when prefixes may be untrusted.
+ *
+ * Returns true only if purge succeeds. Retries because HTML uses long SWR (86400):
+ * a silent purge miss can serve stale content for up to a day.
  */
-export async function purgeWorkersCache(options: PurgeOptions): Promise<void> {
-	try {
-		console.log('[workers cache] purging', options);
-		const result = await cache.purge(options);
-		console.log('[workers cache] purge result', result);
-		if (result && typeof result === 'object' && 'success' in result && result.success === false) {
-			console.error('[workers cache] purge reported failure', result);
+export async function purgeWorkersCache(options: PurgeOptions): Promise<boolean> {
+	const maxAttempts = 3;
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			console.log('[workers cache] purging', { attempt, options });
+			const result = await cache.purge(options);
+			console.log('[workers cache] purge result', result);
+			// Explicit failure only. Missing/undefined result counts as success (API may return void).
+			if (result && typeof result === 'object' && 'success' in result && (result as { success?: boolean }).success === false) {
+				console.error('[workers cache] purge reported failure', result);
+				lastError = result;
+				continue;
+			}
+			return true;
+		} catch (err) {
+			console.error('[workers cache] purge error', { attempt, err });
+			lastError = err;
 		}
-	} catch (err) {
-		console.error('[workers cache] purge error', err);
 	}
+	if (lastError !== undefined) {
+		console.error('[workers cache] purge giving up', lastError);
+	}
+	return false;
 }
+
+
+
 
 /** Canonical request path for a speech filename (percent-encoded; no raw Unicode). */
 export function speechRequestPath(filename: string): string {

--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -540,7 +540,7 @@ async function invalidateSpeechCaches(
 	c: Context<ApiEnv>,
 	filename: string,
 	extraSectionIds: Iterable<number> = []
-) {
+): Promise<boolean> {
 	const host = new URL(c.req.url).host;
 	const encodedFilename = encodeURIComponent(filename);
 	const r2Keys = [
@@ -577,15 +577,17 @@ async function invalidateSpeechCaches(
 
 	const purgeTags = [tags.speech(filename), tags.listHome, tags.listSpeeches, tags.listRss];
 	// Split tags vs pathPrefixes so a bad prefix cannot block tag purge.
-	await Promise.allSettled([
-		...r2Keys.map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)),
+	// R2 deletes are best-effort; Workers Cache purge success is returned (SWR can keep stale for ~1d).
+	await Promise.allSettled(r2Keys.map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	const [tagsOk, pathsOk] = await Promise.all([
 		purgeWorkersCache({ tags: purgeTags }),
 		purgeWorkersCache({ pathPrefixes }),
 	]);
+	return tagsOk && pathsOk;
 }
 
 /** 講者或演講-講者關聯更新後，刪除 R2 origin 並 purge Workers Cache */
-async function invalidateSpeakerCaches(c: Context<ApiEnv>, speakerRoutePathnames: string[]) {
+async function invalidateSpeakerCaches(c: Context<ApiEnv>, speakerRoutePathnames: string[]): Promise<boolean> {
 	const host = new URL(c.req.url).host;
 	const r2Keys = new Set<string>([`${CACHE_KEY_VERSION}/${host}/speakers`]);
 	const pathPrefixes: string[] = [];
@@ -600,18 +602,17 @@ async function invalidateSpeakerCaches(c: Context<ApiEnv>, speakerRoutePathnames
 	const purgeTags = speakerRoutePathnames.map((p) => tags.speaker(p));
 	purgeTags.push(tags.listSpeakers);
 
-	await Promise.allSettled([
-		...Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)),
-		purgeWorkersCache({ tags: purgeTags }),
-		...(pathPrefixes.length > 0 ? [purgeWorkersCache({ pathPrefixes })] : []),
-	]);
+	await Promise.allSettled(Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	const tagsOk = await purgeWorkersCache({ tags: purgeTags });
+	const pathsOk = pathPrefixes.length > 0 ? await purgeWorkersCache({ pathPrefixes }) : true;
+	return tagsOk && pathsOk;
 }
 
 /** 失效列表頁快取：tags only for exact list roots; R2 origin keys still deleted */
 async function invalidateListPageCaches(
 	c: Context<ApiEnv>,
 	{ home, speeches, speakers }: { home: boolean; speeches: boolean; speakers: boolean }
-) {
+): Promise<boolean> {
 	const host = new URL(c.req.url).host;
 	const r2Keys = new Set<string>();
 
@@ -635,10 +636,9 @@ async function invalidateListPageCaches(
 	if (speeches) purgeTags.push(tags.listSpeeches, tags.listRss);
 	if (speakers) purgeTags.push(tags.listSpeakers);
 
-	await Promise.allSettled([
-		...Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)),
-		...(purgeTags.length > 0 ? [purgeWorkersCache({ tags: purgeTags })] : []),
-	]);
+	await Promise.allSettled(Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	// Callers always request at least one list surface; empty tags is a no-op success.
+	return purgeTags.length === 0 ? true : purgeWorkersCache({ tags: purgeTags });
 }
 
 async function syncSearchArtifactsAfterUpsert(c: Context<ApiEnv>, filename: string) {
@@ -769,14 +769,22 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 					);
 				}
 
-				await invalidateSpeechCaches(c, filename, preexistingSectionIds);
-				await invalidateSpeakerCaches(c, speakerRoutePathnames);
-				await invalidateListPageCaches(c, { home: true, speeches: true, speakers: true });
+				const cachePurge = (
+					await Promise.all([
+						invalidateSpeechCaches(c, filename, preexistingSectionIds),
+						invalidateSpeakerCaches(c, speakerRoutePathnames),
+						invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
+					])
+				).every(Boolean);
+				if (!cachePurge) {
+					console.error('[upload_markdown] DELETE cache purge incomplete after D1 commit', { filename });
+				}
 				await syncSearchArtifactsAfterDelete(c, filename);
 
 				return c.json(
 					{
 						success: true,
+						cachePurge,
 						message: `Successfully deleted ${filename}`,
 						deleted: {
 							sections: sectionsDeleted,
@@ -785,7 +793,7 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 							speech: speechDeleted
 						}
 					},
-					200,
+					cachePurge ? 200 : 503,
 					corsHeadersWithMethods
 				);
 		} else if (method === 'POST') {
@@ -852,8 +860,17 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				}
 			}
 
+			let priorSpeakerRoutePathnames: string[] = [];
 			if (existing) {
 				console.log('[upload_markdown] POST speech_index 已存在，先刪除舊資料:', filename);
+				const priorSpeakerRows = await withRetry(() => c.env.DB.prepare(
+					'SELECT speaker_route_pathname FROM speech_speakers WHERE speech_filename = ?'
+				)
+					.bind(filename)
+					.all<{ speaker_route_pathname: string }>());
+				priorSpeakerRoutePathnames = Array.from(
+					new Set((priorSpeakerRows.results ?? []).map((row) => row.speaker_route_pathname).filter(Boolean))
+				);
 				await withRetry(() => c.env.DB.batch([
 					c.env.DB.prepare('DELETE FROM speech_content WHERE filename = ?').bind(filename),
 					c.env.DB.prepare('DELETE FROM speech_speakers WHERE speech_filename = ?').bind(filename),
@@ -892,7 +909,16 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				).bind(filename, display_name, '', '')
 			);
 
-			for (const routePathname of speakerRoutePathnames) {
+			// Relations and speaker rows come only from speakers assigned to final sections.
+			// Marker-only names without a section must not appear on /speakers.
+			const usedSpeakerRoutePathnames = Array.from(
+				new Set(
+					normalized
+						.map((section) => section.section_speaker)
+						.filter((value): value is string => Boolean(value && value.trim()))
+				)
+			);
+			for (const routePathname of usedSpeakerRoutePathnames) {
 				const speakerName = decodeURIComponent(routePathname);
 				metaBatch.push(
 					c.env.DB.prepare(
@@ -903,6 +929,17 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 					c.env.DB.prepare(
 						'INSERT OR IGNORE INTO speech_speakers (speech_filename, speaker_route_pathname) VALUES (?, ?)'
 					).bind(filename, routePathname)
+				);
+			}
+			// Drop orphan speaker rows after replace/reassign (prior + marker-only, not used on sections).
+			const orphanCandidates = Array.from(
+				new Set([...priorSpeakerRoutePathnames, ...speakerRoutePathnames])
+			).filter((routePathname) => !usedSpeakerRoutePathnames.includes(routePathname));
+			for (const routePathname of orphanCandidates) {
+				metaBatch.push(
+					c.env.DB.prepare(
+						'DELETE FROM speakers WHERE route_pathname = ? AND NOT EXISTS (SELECT 1 FROM speech_speakers WHERE speaker_route_pathname = ?)'
+					).bind(routePathname, routePathname)
 				);
 			}
 
@@ -954,17 +991,28 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				await withRetry(() => c.env.DB.batch(sectionBatch));
 			}
 
-			await invalidateSpeechCaches(c, filename);
-			if (altFilename && altFilename !== filename) {
-				await invalidateSpeechCaches(c, altFilename);
+			const cachePurge = (
+				await Promise.all([
+					invalidateSpeechCaches(c, filename),
+					...(altFilename && altFilename !== filename ? [invalidateSpeechCaches(c, altFilename)] : []),
+					invalidateSpeakerCaches(c, Array.from(new Set([...speakerRoutePathnames, ...usedSpeakerRoutePathnames]))),
+					invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
+				])
+			).every(Boolean);
+			if (!cachePurge) {
+				console.error('[upload_markdown] POST cache purge incomplete after D1 commit', { filename });
 			}
-			await invalidateSpeakerCaches(c, speakerRoutePathnames);
-			await invalidateListPageCaches(c, { home: true, speeches: true, speakers: true });
 			await syncSearchArtifactsAfterUpsert(c, filename);
 
 			return c.json(
-				{ success: true, filename, sectionsCount: normalized.length, ...(altFilename ? { alternate_filename: altFilename } : {}) },
-				200,
+				{
+					success: true,
+					cachePurge,
+					filename,
+					sectionsCount: normalized.length,
+					...(altFilename ? { alternate_filename: altFilename } : {})
+				},
+				cachePurge ? 200 : 503,
 				corsHeadersWithMethods
 			);
 		} else if (method === 'PATCH') {
@@ -1101,7 +1149,6 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 			// 既有段落 ID（DB 原本有的）；finalSectionIds = PATCH 後要保留的 ID（供刪除用）
 			const oldSectionIds = new Set(oldSections.map((section) => section.section_id));
 			const finalSectionIds = new Set(normalized.map((section) => section.section_id));
-			const impactedSpeakers = Array.from(new Set([...oldSpeakerRoutePathnames, ...newSpeakerRoutePathnames]));
 
 			// 收集所有 D1 寫入為 batch 一次執行（含 display_name、講者、段落、關聯、孤兒清理）
 			const batchStatements: Parameters<typeof c.env.DB.batch>[0] = [];
@@ -1125,15 +1172,8 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				);
 			}
 
-			// 2. 確保講者存在（冪等 upsert）
-			for (const routePathname of newSpeakerRoutePathnames) {
-				const speakerName = decodeURIComponent(routePathname);
-				batchStatements.push(
-					c.env.DB.prepare(
-						'INSERT INTO speakers (route_pathname, name, photoURL) VALUES (?, ?, NULL) ON CONFLICT(route_pathname) DO NOTHING'
-					).bind(routePathname, speakerName)
-				);
-			}
+			// 2. Speakers upsert happens in step 5 from final section speakers only
+			//    (marker-only names without a section must not appear on /speakers).
 
 			// 3. UPDATE 既有 / INSERT 新增段落
 			for (const section of normalized) {
@@ -1185,11 +1225,27 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				}
 			}
 
-			// 5. 重建演講-講者關聯
+			// 5. 重建演講-講者關聯：只用「段落上實際出現的講者」，單一 batch 完成（無第二階段對帳）
+			const usedSpeakerRoutePathnames = Array.from(
+				new Set(
+					normalized
+						.map((section) => section.section_speaker)
+						.filter((value): value is string => Boolean(value && value.trim()))
+				)
+			);
+			// Upsert speakers that appear on final sections only
+			for (const routePathname of usedSpeakerRoutePathnames) {
+				const speakerName = decodeURIComponent(routePathname);
+				batchStatements.push(
+					c.env.DB.prepare(
+						'INSERT INTO speakers (route_pathname, name, photoURL) VALUES (?, ?, NULL) ON CONFLICT(route_pathname) DO NOTHING'
+					).bind(routePathname, speakerName)
+				);
+			}
 			batchStatements.push(
 				c.env.DB.prepare('DELETE FROM speech_speakers WHERE speech_filename = ?').bind(filename)
 			);
-			for (const routePathname of newSpeakerRoutePathnames) {
+			for (const routePathname of usedSpeakerRoutePathnames) {
 				batchStatements.push(
 					c.env.DB.prepare(
 						'INSERT OR IGNORE INTO speech_speakers (speech_filename, speaker_route_pathname) VALUES (?, ?)'
@@ -1197,8 +1253,11 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				);
 			}
 
-			// 6. 清理孤兒講者
-			for (const routePathname of impactedSpeakers) {
+			// 6. 清理孤兒講者（同一 batch：INSERT 後 NOT EXISTS 在 SQLite batch 內按序可見）
+			const finalImpactedSpeakers = Array.from(
+				new Set([...oldSpeakerRoutePathnames, ...newSpeakerRoutePathnames, ...usedSpeakerRoutePathnames])
+			);
+			for (const routePathname of finalImpactedSpeakers) {
 				batchStatements.push(
 					c.env.DB.prepare(
 						'DELETE FROM speakers WHERE route_pathname = ? AND NOT EXISTS (SELECT 1 FROM speech_speakers WHERE speaker_route_pathname = ?)'
@@ -1208,64 +1267,24 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 
 			await withRetry(() => c.env.DB.batch(batchStatements));
 
-			// PATCH 完成後再對帳一次：僅保留「有實際段落」的演講-講者關聯
-			const relationRows = await withRetry(() => c.env.DB.prepare(
-				'SELECT speaker_route_pathname FROM speech_speakers WHERE speech_filename = ?'
-			)
-				.bind(filename)
-				.all<{ speaker_route_pathname: string }>());
-			const relationRoutePathnames = Array.from(
-				new Set((relationRows.results ?? []).map((row) => row.speaker_route_pathname).filter(Boolean))
-			);
-
-			const usedSpeakerRows = await withRetry(() => c.env.DB.prepare(
-				`SELECT DISTINCT section_speaker
-				 FROM speech_content
-				 WHERE filename = ?
-				   AND section_speaker IS NOT NULL
-				   AND section_speaker != ''`
-			)
-				.bind(filename)
-				.all<{ section_speaker: string }>());
-			const usedSpeakerRoutePathnames = new Set(
-				(usedSpeakerRows.results ?? []).map((row) => row.section_speaker).filter(Boolean)
-			);
-			const relationsToDelete = relationRoutePathnames.filter(
-				(routePathname) => !usedSpeakerRoutePathnames.has(routePathname)
-			);
-
-			// 一次 batch 刪除多餘關聯 + 孤兒講者
-			const finalImpactedSpeakers = Array.from(new Set([...impactedSpeakers, ...relationsToDelete]));
-			if (relationsToDelete.length > 0 || finalImpactedSpeakers.length > 0) {
-				const cleanupBatch: Parameters<typeof c.env.DB.batch>[0] = [];
-				for (const routePathname of relationsToDelete) {
-					cleanupBatch.push(
-						c.env.DB.prepare(
-							'DELETE FROM speech_speakers WHERE speech_filename = ? AND speaker_route_pathname = ?'
-						).bind(filename, routePathname)
-					);
-				}
-				for (const routePathname of finalImpactedSpeakers) {
-					cleanupBatch.push(
-						c.env.DB.prepare(
-							'DELETE FROM speakers WHERE route_pathname = ? AND NOT EXISTS (SELECT 1 FROM speech_speakers WHERE speaker_route_pathname = ?)'
-						).bind(routePathname, routePathname)
-					);
-				}
-				await withRetry(() => c.env.DB.batch(cleanupBatch));
-			}
-
 			// 失效快取：含 PATCH 前的 section IDs（已刪除的 /speech/:id 仍需 purge）
 			const preexistingSectionIds = oldSections.map((section) => section.section_id);
-			await invalidateSpeechCaches(c, filename, preexistingSectionIds);
-			const affectedAlternateFilenames = Array.from(
-				new Set([currentAlternateFilename, desiredAlternateFilename].filter((value): value is string => Boolean(value && value !== filename)))
-			);
-			for (const alternateFilename of affectedAlternateFilenames) {
-				await invalidateSpeechCaches(c, alternateFilename);
+			const purgeResults = await Promise.all([
+				invalidateSpeechCaches(c, filename, preexistingSectionIds),
+				...Array.from(
+					new Set(
+						[currentAlternateFilename, desiredAlternateFilename].filter(
+							(value): value is string => Boolean(value && value !== filename)
+						)
+					)
+				).map((alternateFilename) => invalidateSpeechCaches(c, alternateFilename)),
+				invalidateSpeakerCaches(c, finalImpactedSpeakers),
+				invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
+			]);
+			const cachePurge = purgeResults.every(Boolean);
+			if (!cachePurge) {
+				console.error('[upload_markdown] PATCH cache purge incomplete after D1 commit', { filename });
 			}
-			await invalidateSpeakerCaches(c, finalImpactedSpeakers);
-			await invalidateListPageCaches(c, { home: true, speeches: true, speakers: true });
 			await syncSearchArtifactsAfterUpsert(c, filename);
 
 			return c.json(
@@ -1276,9 +1295,11 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 					sectionsCount: normalized.length,
 					insertedCount: normalized.filter((section) => !oldSectionIds.has(section.section_id)).length,
 					updatedCount: normalized.filter((section) => oldSectionIds.has(section.section_id)).length,
-					deletedCount: oldSections.filter((section) => !finalSectionIds.has(section.section_id)).length
+					deletedCount: oldSections.filter((section) => !finalSectionIds.has(section.section_id)).length,
+					cachePurge
 				},
-				200,
+				// 503 when D1 wrote but long-SWR front cache may still serve stale HTML
+				cachePurge ? 200 : 503,
 				corsHeadersWithMethods
 			);
 		} else {

--- a/test/cache_unit.spec.ts
+++ b/test/cache_unit.spec.ts
@@ -167,3 +167,41 @@ describe('speech/speaker request paths', () => {
 		expect(speakerRequestPath(encoded)).not.toContain('%25');
 	});
 });
+
+
+describe('purgeWorkersCache reliability', () => {
+	it('returns true when purge succeeds or returns no explicit failure', async () => {
+		const mod = await import('cloudflare:workers');
+		const original = mod.cache.purge;
+		mod.cache.purge = (async () => ({ success: true })) as typeof mod.cache.purge;
+		try {
+			await expect(purgeWorkersCache({ tags: ['list:home'] })).resolves.toBe(true);
+		} finally {
+			mod.cache.purge = original;
+		}
+	});
+
+	it('returns false after repeated explicit purge failures', async () => {
+		const mod = await import('cloudflare:workers');
+		const original = mod.cache.purge;
+		mod.cache.purge = (async () => ({ success: false })) as typeof mod.cache.purge;
+		try {
+			await expect(purgeWorkersCache({ tags: ['list:home'] })).resolves.toBe(false);
+		} finally {
+			mod.cache.purge = original;
+		}
+	});
+
+	it('returns false after repeated thrown purge errors', async () => {
+		const mod = await import('cloudflare:workers');
+		const original = mod.cache.purge;
+		mod.cache.purge = (async () => {
+			throw new Error('purge transport failed');
+		}) as typeof mod.cache.purge;
+		try {
+			await expect(purgeWorkersCache({ tags: ['list:home'] })).resolves.toBe(false);
+		} finally {
+			mod.cache.purge = original;
+		}
+	});
+});

--- a/test/og_speech_cache_hit.spec.ts
+++ b/test/og_speech_cache_hit.spec.ts
@@ -1,0 +1,85 @@
+import { createExecutionContext } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import { CACHE_KEY_VERSION } from '../src/cacheKeyVersion';
+import worker from '../src/index';
+
+const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+
+describe('og speech R2 hit tagging', () => {
+	it('sets Cache-Tag when sections lookup returns filename', async () => {
+		const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'x',
+			BESTIAN_TRANSCRIPT_TOKEN: 'y',
+			ASSETS: { fetch: () => new Response('Not Found', { status: 404 }) },
+			SPEECH_CACHE: {
+				get: async (key: string) => {
+					if (key === `${CACHE_KEY_VERSION}/og/speech/7.png`) {
+						return { body: png, arrayBuffer: async () => png.buffer };
+					}
+					return null;
+				},
+				put: async () => {},
+				delete: async () => true,
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: (sql: string) => ({
+					bind: (..._args: unknown[]) => ({
+						first: async () => {
+							if (sql.includes('FROM sections WHERE section_id')) {
+								return { filename: 'demo-speech' };
+							}
+							return null;
+						},
+						all: async () => ({ success: true, results: [] })
+					}),
+					first: async () => null,
+					all: async () => ({ success: true, results: [] })
+				})
+			}
+		};
+		const req = new IncomingRequest('https://example.com/og/speech/7.png');
+		const res = await worker.fetch(req, env as any, createExecutionContext());
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Cache-Tag')).toContain('speech:');
+	});
+
+	it('still serves cached PNG when sections lookup throws', async () => {
+		const png = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'x',
+			BESTIAN_TRANSCRIPT_TOKEN: 'y',
+			ASSETS: { fetch: () => new Response('Not Found', { status: 404 }) },
+			SPEECH_CACHE: {
+				get: async (key: string) => {
+					if (key === `${CACHE_KEY_VERSION}/og/speech/8.png`) {
+						return { body: png, arrayBuffer: async () => png.buffer };
+					}
+					return null;
+				},
+				put: async () => {},
+				delete: async () => true,
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: () => ({
+					bind: () => ({
+						first: async () => {
+							throw new Error('db down');
+						},
+						all: async () => ({ success: true, results: [] })
+					}),
+					first: async () => {
+						throw new Error('db down');
+					},
+					all: async () => ({ success: true, results: [] })
+				})
+			}
+		};
+		const req = new IncomingRequest('https://example.com/og/speech/8.png');
+		const res = await worker.fetch(req, env as any, createExecutionContext());
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toContain('image/png');
+	});
+});

--- a/test/setup-cache-isolation.ts
+++ b/test/setup-cache-isolation.ts
@@ -1,7 +1,19 @@
 // Public routes no longer use caches.default (Workers Cache is front-of-Worker).
-// Kept as an empty setup file so vitest.config.mts setupFiles path stays valid.
-import { beforeEach } from 'vitest';
+// Mock cloudflare:workers cache.purge so upload invalidation tests can assert
+// success without a real Workers Cache purge API in the vitest pool.
 
-beforeEach(() => {
-	// no-op
+import { beforeEach, vi } from 'vitest';
+
+vi.mock('cloudflare:workers', () => ({
+	cache: {
+		purge: vi.fn(async () => ({ success: true })),
+	},
+}));
+
+beforeEach(async () => {
+	const { cache } = await import('cloudflare:workers');
+	if (cache?.purge && 'mockReset' in cache.purge) {
+		(cache.purge as ReturnType<typeof vi.fn>).mockReset();
+		(cache.purge as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+	}
 });

--- a/test/upload_markdown.spec.ts
+++ b/test/upload_markdown.spec.ts
@@ -119,7 +119,10 @@ function createUploadEnv(options?: {
 				}))
 			};
 		}
-		if (sql.includes('FROM speech_speakers WHERE speech_filename = ?')) {
+		if (sql.includes('FROM speech_speakers WHERE speech_filename = ?') || sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
+			if (args[0] === 'demo-speech') {
+				return { success: true, results: [{ speaker_route_pathname: 'ZOMBIE' }] };
+			}
 			return { success: true, results: [] };
 		}
 		if (sql.includes('SELECT DISTINCT section_speaker')) {
@@ -227,6 +230,7 @@ describe('upload_markdown PATCH', () => {
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
 			success: true,
+			cachePurge: true,
 			filename: 'demo-speech',
 			sectionsCount: 3,
 			insertedCount: 1,
@@ -279,9 +283,7 @@ describe('upload_markdown PATCH', () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({
-			success: true,
-			filename: 'demo-speech',
+		expect(await res.json()).toEqual({ success: true, cachePurge: true, filename: 'demo-speech',
 			alternate_filename: 'paired-speech',
 			sectionsCount: 2,
 			insertedCount: 0,
@@ -348,6 +350,7 @@ describe('upload_markdown POST', () => {
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
 			success: true,
+			cachePurge: true,
 			filename: 'fresh-speech',
 			sectionsCount: 1,
 			alternate_filename: 'paired-speech'
@@ -642,3 +645,302 @@ describe('upload_markdown DELETE purges preexisting section caches', () => {
 	});
 });
 
+
+
+describe('invalidateSpeechCaches section query failure', () => {
+	it('still returns success when section_id re-query throws after PATCH', async () => {
+		const env = createUploadEnv();
+		const originalPrepare = env.DB.prepare.bind(env.DB);
+		let patchDone = false;
+		env.DB.prepare = (sql: string) => {
+			const stmt = originalPrepare(sql);
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
+				return {
+					bind: (...args: unknown[]) => ({
+						first: async () => {
+							throw new Error('section re-query failed');
+						},
+						all: async () => {
+							throw new Error('section re-query failed');
+						},
+						sql,
+						args
+					}),
+					first: async () => {
+						throw new Error('section re-query failed');
+					},
+					all: async () => {
+						throw new Error('section re-query failed');
+					}
+				} as any;
+			}
+			return stmt;
+		};
+		// Force invalidate path: normal PATCH
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha\n\nBeta'
+			})
+		});
+		// D1 wrote; section re-query fail is swallowed inside invalidate; purge may still succeed
+		expect([200, 503]).toContain(res.status);
+	});
+});
+
+
+describe('upload_markdown cachePurge failures', () => {
+	it('returns 503 when cache purge fails after PATCH', async () => {
+		const { cache } = await import('cloudflare:workers');
+		const purge = cache.purge as ReturnType<typeof import('vitest').vi.fn>;
+		purge.mockResolvedValue({ success: false });
+
+		const env = createUploadEnv();
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha\n\nBeta'
+			})
+		});
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(false);
+	});
+});
+
+
+describe('upload_markdown cachePurge failures for DELETE/POST', () => {
+	it('returns 503 when cache purge fails after DELETE', async () => {
+		const { cache } = await import('cloudflare:workers');
+		const purge = cache.purge as ReturnType<typeof import('vitest').vi.fn>;
+		purge.mockResolvedValue({ success: false });
+
+		// Reuse delete-style env from createUploadEnv is weak; use lightweight env
+		const deletedKeys: string[] = [];
+		let liveSections = [{ section_id: 1 }];
+		const env = {
+			AUDREYT_TRANSCRIPT_TOKEN: 'token-audrey',
+			BESTIAN_TRANSCRIPT_TOKEN: 'token-bestian',
+			ASSETS: { fetch: () => new Response('Not Found', { status: 404 }) },
+			SPEECH_CACHE: {
+				delete: async (key: string) => { deletedKeys.push(key); return true; },
+				get: async () => null,
+				put: async () => {},
+				list: async () => ({ objects: [], truncated: false, cursor: '' })
+			},
+			DB: {
+				prepare: (sql: string) => {
+					const run = (args: unknown[] = []) => ({
+						sql,
+						args,
+						first: async () => null,
+						all: async () => {
+							if (sql.includes('FROM speech_redirects')) return { success: true, results: [] };
+							if (sql.includes('speech_speakers')) return { success: true, results: [] };
+							if (sql.includes('SELECT section_id FROM speech_content')) {
+								return { success: true, results: liveSections.map((s) => ({ section_id: s.section_id })) };
+							}
+							return { success: true, results: [] };
+						}
+					});
+					return Object.assign(run([]), { bind: (...args: unknown[]) => run(args) });
+				},
+				batch: async (statements: Array<{ sql?: string }>) => {
+					for (const stmt of statements) {
+						if (stmt.sql?.startsWith('DELETE FROM speech_content WHERE filename = ?')) liveSections = [];
+					}
+					return statements.map((stmt) => {
+						const sql = stmt.sql ?? '';
+						if (sql.startsWith('DELETE FROM speech_content')) return { meta: { changes: 1 } };
+						if (sql.startsWith('DELETE FROM speech_index')) return { meta: { changes: 1 } };
+						return { meta: { changes: 0 } };
+					});
+				}
+			}
+		} as any;
+
+		const { res } = await request('/api/upload_markdown?filename=demo-speech', env, {
+			method: 'DELETE',
+			headers: { Authorization: 'Bearer token-audrey' }
+		});
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(false);
+	});
+
+	it('returns 503 when cache purge fails after POST', async () => {
+		const { cache } = await import('cloudflare:workers');
+		const purge = cache.purge as ReturnType<typeof import('vitest').vi.fn>;
+		purge.mockResolvedValue({ success: false });
+		const env = createUploadEnv();
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'brand-new-speech',
+				markdown: '# Brand New\n## Speaker:\nhello'
+			})
+		});
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(false);
+	});
+
+	it('POST replace prefetches prior speakers and cleans orphans', async () => {
+		const env = createUploadEnv();
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				// Same title as existing display_name so no collision rename; no speaker on sections
+				markdown: '# Demo Speech\nOnly body no speaker mark'
+			})
+		});
+		expect([200, 503]).toContain(res.status);
+		const orphanDeletes = env.__operations.filter((s) =>
+			s.sql.includes('DELETE FROM speakers WHERE route_pathname = ? AND NOT EXISTS')
+			&& s.args[0] === 'ZOMBIE'
+		);
+		expect(orphanDeletes.length).toBeGreaterThan(0);
+	});
+});
+
+
+describe('upload_markdown defensive branches', () => {
+	it('covers null section_content and non-Error catch', async () => {
+		// 1) PATCH with null section_content on old rows
+		const env = createUploadEnv();
+		const originalPrepare = env.DB.prepare.bind(env.DB);
+		env.DB.prepare = (sql: string) => {
+			const stmt = originalPrepare(sql);
+			if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
+				return {
+					bind: (...args: unknown[]) => ({
+						sql,
+						args,
+						first: async () => null,
+						all: async () => ({
+							success: true,
+							results: [
+								{
+									section_id: 100,
+									previous_section_id: null,
+									next_section_id: 101,
+									section_speaker: null,
+									section_content: null
+								},
+								{
+									section_id: 101,
+									previous_section_id: 100,
+									next_section_id: null,
+									section_speaker: null,
+									section_content: null
+								}
+							]
+						})
+					}),
+					first: async () => null,
+					all: async () => ({ success: true, results: [] })
+				} as any;
+			}
+			return stmt;
+		};
+
+		const ok = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha\n\nBeta'
+			})
+		});
+		expect([200, 503]).toContain(ok.res.status);
+
+		// 2) non-Error throw path in outer catch
+		const boomEnv = createUploadEnv();
+		boomEnv.DB.prepare = () => {
+			throw 'string-boom';
+		};
+		const bad = await request('/api/upload_markdown', boomEnv, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha'
+			})
+		});
+		expect(bad.res.status).toBe(503);
+		const json = await bad.res.json() as { detail: string };
+		expect(json.detail).toContain('string-boom');
+	});
+});
+
+
+describe('upload_markdown PATCH empty result containers', () => {
+	it('handles undefined results arrays on PATCH load', async () => {
+		const env = createUploadEnv();
+		const originalPrepare = env.DB.prepare.bind(env.DB);
+		env.DB.prepare = (sql: string) => {
+			const stmt = originalPrepare(sql);
+			if (sql.includes('FROM speech_content') && sql.includes('ORDER BY section_id ASC')) {
+				return {
+					bind: () => ({
+						first: async () => null,
+						all: async () => ({ success: true }) // results undefined
+					}),
+					first: async () => null,
+					all: async () => ({ success: true })
+				} as any;
+			}
+			if (sql.includes('FROM speech_speakers WHERE speech_filename = ?') || sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
+				return {
+					bind: () => ({
+						first: async () => null,
+						all: async () => ({ success: true }) // results undefined
+					}),
+					first: async () => null,
+					all: async () => ({ success: true })
+				} as any;
+			}
+			return stmt;
+		};
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nOnly one section'
+			})
+		});
+		expect([200, 503]).toContain(res.status);
+	});
+});

--- a/test/upload_markdown_direct.spec.ts
+++ b/test/upload_markdown_direct.spec.ts
@@ -151,15 +151,25 @@ describe('uploadMarkdown PATCH — orphan speech_speakers cleanup', () => {
 		const res = await uploadMarkdown(ctx);
 		expect(res.status).toBe(200);
 
-		const cleanupSqls = batchStatements.map((s) => s.sql).filter((sql) =>
-			sql.includes('DELETE FROM speech_speakers WHERE speech_filename = ? AND speaker_route_pathname = ?')
+		// Single-batch rebuild: wipe all speech_speakers for the speech, re-insert only used speakers.
+		const wipeRelations = batchStatements.filter((s) =>
+			s.sql === 'DELETE FROM speech_speakers WHERE speech_filename = ?'
+			&& s.args[0] === 'orphan-demo'
 		);
-		expect(cleanupSqls.length).toBeGreaterThan(0);
-		// Check that ZOMBIE is the one deleted
-		const zombieCleanups = batchStatements.filter((s) =>
-			s.sql.includes('DELETE FROM speech_speakers WHERE speech_filename = ? AND speaker_route_pathname = ?')
-			&& s.args[1] === 'ZOMBIE'
+		expect(wipeRelations.length).toBeGreaterThan(0);
+
+		const relationInserts = batchStatements.filter((s) =>
+			s.sql.includes('INSERT OR IGNORE INTO speech_speakers')
 		);
-		expect(zombieCleanups.length).toBe(1);
+		const insertedSpeakers = relationInserts.map((s) => s.args[1]);
+		expect(insertedSpeakers).toContain('A');
+		expect(insertedSpeakers).not.toContain('ZOMBIE');
+
+		// Orphan speaker row cleanup for removed route.
+		const zombieSpeakerDeletes = batchStatements.filter((s) =>
+			s.sql.includes('DELETE FROM speakers WHERE route_pathname = ?')
+			&& s.args[0] === 'ZOMBIE'
+		);
+		expect(zombieSpeakerDeletes.length).toBeGreaterThan(0);
 	});
 });

--- a/test/upload_markdown_post.spec.ts
+++ b/test/upload_markdown_post.spec.ts
@@ -128,7 +128,7 @@ describe('POST /api/upload_markdown — new speech creation', () => {
 
 		expect(res.status).toBe(200);
 		const json = (await res.json()) as { success: boolean; filename: string; sectionsCount: number };
-		expect(json).toEqual({ success: true, filename: 'new-speech', sectionsCount: 2 });
+		expect(json).toEqual({ success: true, cachePurge: true, filename: 'new-speech', sectionsCount: 2 });
 
 		const indexInsert = env.__operations.find((s) => s.sql.startsWith('INSERT INTO speech_index'));
 		expect(indexInsert).toBeDefined();


### PR DESCRIPTION
## Summary

Fixes remaining PATCH hazards **3** (two-phase speaker DB) and **6** (best-effort purge under long SWR).

### Issue 3
- Rebuild `speech_speakers` from **final section speakers** in the main batch
- Remove second post-batch reconciliation
- POST: section-assigned speakers only; prefetch prior speakers on replace for orphan cleanup

### Issue 6
- `purgeWorkersCache` returns boolean, retries, fails on throw/`success:false`
- Upload responses include `cachePurge`; **503** when D1 ok but purge failed
- Vitest mocks `cache.purge` success in setup (production stays strict)

Closes #152.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test:coverage` (100% stmts/lines/funcs per file)
- [ ] Deploy + smoke