### PR TITLE
fix(cache): require R2 origin delete success in invalidation

### DIFF
--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -139,13 +139,15 @@ export async function writeR2Cache(
 	}
 }
 
-/** 刪除 R2 快取 */
-export async function deleteR2Cache(bucket: R2Bucket, cacheKey: string) {
+/** 刪除 R2 origin 快取。成功 true；失敗 false（不可靜默，否則 front MISS 會從髒 R2 回填）。 */
+export async function deleteR2Cache(bucket: R2Bucket, cacheKey: string): Promise<boolean> {
 	try {
 		await bucket.delete(cacheKey);
 		console.log('[r2 cache] deleted', cacheKey);
+		return true;
 	} catch (err) {
 		console.error('[r2 cache] delete error', cacheKey, err);
+		return false;
 	}
 }
 

--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -576,14 +576,19 @@ async function invalidateSpeechCaches(
 	}
 
 	const purgeTags = [tags.speech(filename), tags.listHome, tags.listSpeeches, tags.listRss];
+	// Both tiers must clear: R2 origin delete AND Workers Cache purge.
+	// If R2 delete fails but front purge succeeds, the next MISS re-poisons the front from stale R2.
+	const r2Results = await Promise.all(r2Keys.map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	const r2Ok = r2Results.every(Boolean);
+	if (!r2Ok) {
+		console.error('[invalidate] R2 origin delete incomplete', { filename, failed: r2Results.filter((ok) => !ok).length });
+	}
 	// Split tags vs pathPrefixes so a bad prefix cannot block tag purge.
-	// R2 deletes are best-effort; Workers Cache purge success is returned (SWR can keep stale for ~1d).
-	await Promise.allSettled(r2Keys.map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
 	const [tagsOk, pathsOk] = await Promise.all([
 		purgeWorkersCache({ tags: purgeTags }),
 		purgeWorkersCache({ pathPrefixes }),
 	]);
-	return tagsOk && pathsOk;
+	return r2Ok && tagsOk && pathsOk;
 }
 
 /** 講者或演講-講者關聯更新後，刪除 R2 origin 並 purge Workers Cache */
@@ -602,10 +607,16 @@ async function invalidateSpeakerCaches(c: Context<ApiEnv>, speakerRoutePathnames
 	const purgeTags = speakerRoutePathnames.map((p) => tags.speaker(p));
 	purgeTags.push(tags.listSpeakers);
 
-	await Promise.allSettled(Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	const r2Results = await Promise.all(Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	const r2Ok = r2Results.every(Boolean);
+	if (!r2Ok) {
+		console.error('[invalidate] speaker R2 origin delete incomplete', {
+			failed: r2Results.filter((ok) => !ok).length
+		});
+	}
 	const tagsOk = await purgeWorkersCache({ tags: purgeTags });
 	const pathsOk = pathPrefixes.length > 0 ? await purgeWorkersCache({ pathPrefixes }) : true;
-	return tagsOk && pathsOk;
+	return r2Ok && tagsOk && pathsOk;
 }
 
 /** 失效列表頁快取：tags only for exact list roots; R2 origin keys still deleted */
@@ -636,9 +647,16 @@ async function invalidateListPageCaches(
 	if (speeches) purgeTags.push(tags.listSpeeches, tags.listRss);
 	if (speakers) purgeTags.push(tags.listSpeakers);
 
-	await Promise.allSettled(Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
-	// Callers always request at least one list surface; empty tags is a no-op success.
-	return purgeTags.length === 0 ? true : purgeWorkersCache({ tags: purgeTags });
+	const r2Results = await Promise.all(Array.from(r2Keys).map((key) => deleteR2Cache(c.env.SPEECH_CACHE, key)));
+	const r2Ok = r2Results.every(Boolean);
+	if (!r2Ok) {
+		console.error('[invalidate] list R2 origin delete incomplete', {
+			failed: r2Results.filter((ok) => !ok).length
+		});
+	}
+	// Callers always request at least one list surface; empty tags is a no-op for front purge.
+	const purgeOk = purgeTags.length === 0 ? true : await purgeWorkersCache({ tags: purgeTags });
+	return r2Ok && purgeOk;
 }
 
 async function syncSearchArtifactsAfterUpsert(c: Context<ApiEnv>, filename: string) {

--- a/test/cache_unit.spec.ts
+++ b/test/cache_unit.spec.ts
@@ -111,7 +111,12 @@ describe('cache.readR2Cache / writeR2Cache', () => {
 
 		expect(await readR2Cache(broken, 'k')).toBeNull();
 		await writeR2Cache(broken, 'k', new Response('x'));
-		await deleteR2Cache(broken, 'k');
+		await expect(deleteR2Cache(broken, 'k')).resolves.toBe(false);
+	});
+
+	it('returns true when R2 delete succeeds', async () => {
+		const { bucket } = createBucket();
+		await expect(deleteR2Cache(bucket, 'missing-is-ok')).resolves.toBe(true);
 	});
 });
 

--- a/test/upload_markdown.spec.ts
+++ b/test/upload_markdown.spec.ts
@@ -944,3 +944,28 @@ describe('upload_markdown PATCH empty result containers', () => {
 		expect([200, 503]).toContain(res.status);
 	});
 });
+
+
+describe('upload_markdown R2 origin delete failures', () => {
+	it('returns 503 when R2 origin delete fails after PATCH even if Workers purge succeeds', async () => {
+		const env = createUploadEnv();
+		env.SPEECH_CACHE.delete = async () => {
+			throw new Error('r2 delete failed');
+		};
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha\n\nBeta'
+			})
+		});
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the R2-origin re-poison gap: front purge success alone is not freshness if SPEECH_CACHE still holds stale HTML/artifacts.

- `deleteR2Cache` → `Promise<boolean>`
- Invalidators: `r2Ok && purgeOk` (not purge-only)
- Upload `cachePurge` / 503 already covers combined failure
- Tests: R2 delete false; PATCH returns 503 when R2 delete throws

Closes #154.

## Test plan
- [x] typecheck
- [x] test:coverage 100% stmts/lines/funcs
- [ ] deploy