### PR TITLE
fix(upload): fail-visible search artifact sync

### DIFF
--- a/src/api/upload_markdown.ts
+++ b/src/api/upload_markdown.ts
@@ -659,28 +659,34 @@ async function invalidateListPageCaches(
 	return r2Ok && purgeOk;
 }
 
-async function syncSearchArtifactsAfterUpsert(c: Context<ApiEnv>, filename: string) {
+async function syncSearchArtifactsAfterUpsert(c: Context<ApiEnv>, filename: string): Promise<boolean> {
 	const results = await Promise.allSettled([
 		writeSearchOverlayForSpeech(c, filename),
 		syncSearchStats(c)
 	]);
+	let ok = true;
 	for (const result of results) {
 		if (result.status === 'rejected') {
+			ok = false;
 			console.error('[upload_markdown] search upsert sync error', result.reason);
 		}
 	}
+	return ok;
 }
 
-async function syncSearchArtifactsAfterDelete(c: Context<ApiEnv>, filename: string) {
+async function syncSearchArtifactsAfterDelete(c: Context<ApiEnv>, filename: string): Promise<boolean> {
 	const results = await Promise.allSettled([
 		markSpeechDeletedInSearch(c.env.SPEECH_CACHE, filename),
 		syncSearchStats(c)
 	]);
+	let ok = true;
 	for (const result of results) {
 		if (result.status === 'rejected') {
+			ok = false;
 			console.error('[upload_markdown] search delete sync error', result.reason);
 		}
 	}
+	return ok;
 }
 
 /** 上傳 Markdown API：支援 POST（新增）、PATCH（更新）、DELETE（刪除），需 Bearer token 驗證 */
@@ -787,22 +793,27 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 					);
 				}
 
-				const cachePurge = (
-					await Promise.all([
+				const [cachePurge, searchSync] = await Promise.all([
+					Promise.all([
 						invalidateSpeechCaches(c, filename, preexistingSectionIds),
 						invalidateSpeakerCaches(c, speakerRoutePathnames),
 						invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
-					])
-				).every(Boolean);
-				if (!cachePurge) {
-					console.error('[upload_markdown] DELETE cache purge incomplete after D1 commit', { filename });
+					]).then((parts) => parts.every(Boolean)),
+					syncSearchArtifactsAfterDelete(c, filename),
+				]);
+				if (!cachePurge || !searchSync) {
+					console.error('[upload_markdown] DELETE post-commit invalidation incomplete', {
+						filename,
+						cachePurge,
+						searchSync
+					});
 				}
-				await syncSearchArtifactsAfterDelete(c, filename);
 
 				return c.json(
 					{
 						success: true,
 						cachePurge,
+						searchSync,
 						message: `Successfully deleted ${filename}`,
 						deleted: {
 							sections: sectionsDeleted,
@@ -811,7 +822,7 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 							speech: speechDeleted
 						}
 					},
-					cachePurge ? 200 : 503,
+					cachePurge && searchSync ? 200 : 503,
 					corsHeadersWithMethods
 				);
 		} else if (method === 'POST') {
@@ -1009,28 +1020,33 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 				await withRetry(() => c.env.DB.batch(sectionBatch));
 			}
 
-			const cachePurge = (
-				await Promise.all([
+			const [cachePurge, searchSync] = await Promise.all([
+				Promise.all([
 					invalidateSpeechCaches(c, filename),
 					...(altFilename && altFilename !== filename ? [invalidateSpeechCaches(c, altFilename)] : []),
 					invalidateSpeakerCaches(c, Array.from(new Set([...speakerRoutePathnames, ...usedSpeakerRoutePathnames]))),
 					invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
-				])
-			).every(Boolean);
-			if (!cachePurge) {
-				console.error('[upload_markdown] POST cache purge incomplete after D1 commit', { filename });
+				]).then((parts) => parts.every(Boolean)),
+				syncSearchArtifactsAfterUpsert(c, filename),
+			]);
+			if (!cachePurge || !searchSync) {
+				console.error('[upload_markdown] POST post-commit invalidation incomplete', {
+					filename,
+					cachePurge,
+					searchSync
+				});
 			}
-			await syncSearchArtifactsAfterUpsert(c, filename);
 
 			return c.json(
 				{
 					success: true,
 					cachePurge,
+					searchSync,
 					filename,
 					sectionsCount: normalized.length,
 					...(altFilename ? { alternate_filename: altFilename } : {})
 				},
-				cachePurge ? 200 : 503,
+				cachePurge && searchSync ? 200 : 503,
 				corsHeadersWithMethods
 			);
 		} else if (method === 'PATCH') {
@@ -1287,23 +1303,28 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 
 			// 失效快取：含 PATCH 前的 section IDs（已刪除的 /speech/:id 仍需 purge）
 			const preexistingSectionIds = oldSections.map((section) => section.section_id);
-			const purgeResults = await Promise.all([
-				invalidateSpeechCaches(c, filename, preexistingSectionIds),
-				...Array.from(
-					new Set(
-						[currentAlternateFilename, desiredAlternateFilename].filter(
-							(value): value is string => Boolean(value && value !== filename)
+			const [cachePurge, searchSync] = await Promise.all([
+				Promise.all([
+					invalidateSpeechCaches(c, filename, preexistingSectionIds),
+					...Array.from(
+						new Set(
+							[currentAlternateFilename, desiredAlternateFilename].filter(
+								(value): value is string => Boolean(value && value !== filename)
+							)
 						)
-					)
-				).map((alternateFilename) => invalidateSpeechCaches(c, alternateFilename)),
-				invalidateSpeakerCaches(c, finalImpactedSpeakers),
-				invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
+					).map((alternateFilename) => invalidateSpeechCaches(c, alternateFilename)),
+					invalidateSpeakerCaches(c, finalImpactedSpeakers),
+					invalidateListPageCaches(c, { home: true, speeches: true, speakers: true }),
+				]).then((parts) => parts.every(Boolean)),
+				syncSearchArtifactsAfterUpsert(c, filename),
 			]);
-			const cachePurge = purgeResults.every(Boolean);
-			if (!cachePurge) {
-				console.error('[upload_markdown] PATCH cache purge incomplete after D1 commit', { filename });
+			if (!cachePurge || !searchSync) {
+				console.error('[upload_markdown] PATCH post-commit invalidation incomplete', {
+					filename,
+					cachePurge,
+					searchSync
+				});
 			}
-			await syncSearchArtifactsAfterUpsert(c, filename);
 
 			return c.json(
 				{
@@ -1314,10 +1335,11 @@ export async function uploadMarkdown(c: Context<ApiEnv>) {
 					insertedCount: normalized.filter((section) => !oldSectionIds.has(section.section_id)).length,
 					updatedCount: normalized.filter((section) => oldSectionIds.has(section.section_id)).length,
 					deletedCount: oldSections.filter((section) => !finalSectionIds.has(section.section_id)).length,
-					cachePurge
+					cachePurge,
+					searchSync
 				},
-				// 503 when D1 wrote but long-SWR front cache may still serve stale HTML
-				cachePurge ? 200 : 503,
+				// 503 when D1 wrote but cache and/or search artifacts incomplete
+				cachePurge && searchSync ? 200 : 503,
 				corsHeadersWithMethods
 			);
 		} else {

--- a/test/upload_markdown.spec.ts
+++ b/test/upload_markdown.spec.ts
@@ -230,7 +230,7 @@ describe('upload_markdown PATCH', () => {
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
 			success: true,
-			cachePurge: true,
+			cachePurge: true, searchSync: true,
 			filename: 'demo-speech',
 			sectionsCount: 3,
 			insertedCount: 1,
@@ -283,7 +283,7 @@ describe('upload_markdown PATCH', () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ success: true, cachePurge: true, filename: 'demo-speech',
+		expect(await res.json()).toEqual({ success: true, cachePurge: true, searchSync: true, filename: 'demo-speech',
 			alternate_filename: 'paired-speech',
 			sectionsCount: 2,
 			insertedCount: 0,
@@ -350,7 +350,7 @@ describe('upload_markdown POST', () => {
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({
 			success: true,
-			cachePurge: true,
+			cachePurge: true, searchSync: true,
 			filename: 'fresh-speech',
 			sectionsCount: 1,
 			alternate_filename: 'paired-speech'
@@ -569,6 +569,9 @@ describe('upload_markdown DELETE purges preexisting section caches', () => {
 			if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
 				return { success: true, results: liveSections.map(({ section_id }) => ({ section_id })) };
 			}
+			if (sql.includes('SELECT COUNT(*) AS count')) {
+				return { success: true, results: [{ count: 0 }] };
+			}
 			if (sql.includes('FROM speech_index WHERE filename = ?')) {
 				return {
 					success: true,
@@ -713,7 +716,7 @@ describe('upload_markdown cachePurge failures', () => {
 			})
 		});
 		expect(res.status).toBe(503);
-		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
 		expect(json.success).toBe(true);
 		expect(json.cachePurge).toBe(false);
 	});
@@ -775,9 +778,11 @@ describe('upload_markdown cachePurge failures for DELETE/POST', () => {
 			headers: { Authorization: 'Bearer token-audrey' }
 		});
 		expect(res.status).toBe(503);
-		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
 		expect(json.success).toBe(true);
 		expect(json.cachePurge).toBe(false);
+		expect(json.searchSync).toBe(true);
+		expect(json.searchSync).toBe(true);
 	});
 
 	it('returns 503 when cache purge fails after POST', async () => {
@@ -797,9 +802,11 @@ describe('upload_markdown cachePurge failures for DELETE/POST', () => {
 			})
 		});
 		expect(res.status).toBe(503);
-		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
 		expect(json.success).toBe(true);
 		expect(json.cachePurge).toBe(false);
+		expect(json.searchSync).toBe(true);
+		expect(json.searchSync).toBe(true);
 	});
 
 	it('POST replace prefetches prior speakers and cleans orphans', async () => {
@@ -964,8 +971,39 @@ describe('upload_markdown R2 origin delete failures', () => {
 			})
 		});
 		expect(res.status).toBe(503);
-		const json = await res.json() as { success: boolean; cachePurge: boolean };
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
 		expect(json.success).toBe(true);
 		expect(json.cachePurge).toBe(false);
+		expect(json.searchSync).toBe(true);
+	});
+});
+
+
+describe('upload_markdown search artifact sync failures', () => {
+	it('returns 503 when search overlay sync fails after PATCH', async () => {
+		const env = createUploadEnv();
+		const originalPut = env.SPEECH_CACHE.put.bind(env.SPEECH_CACHE);
+		env.SPEECH_CACHE.put = async (key: string, body: string) => {
+			if (String(key).startsWith('search-updates/') || key === 'stats.json' || key === 'search-index-manifest.json') {
+				throw new Error('search r2 write failed');
+			}
+			return originalPut(key, body);
+		};
+		const { res } = await request('/api/upload_markdown', env, {
+			method: 'PATCH',
+			headers: {
+				Authorization: 'Bearer token-audrey',
+				'Content-Type': 'application/json; charset=utf-8'
+			},
+			body: JSON.stringify({
+				filename: 'demo-speech',
+				markdown: '# Demo Speech\nAlpha\n\nBeta'
+			})
+		});
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(true);
+		expect(json.searchSync).toBe(false);
 	});
 });

--- a/test/upload_markdown_edges.spec.ts
+++ b/test/upload_markdown_edges.spec.ts
@@ -326,7 +326,7 @@ describe('invalidateSpeakerCaches empty-route skip branch', () => {
 });
 
 describe('syncSearchArtifacts error logging', () => {
-	it('logs but does not fail upsert when the search sync rejects', async () => {
+	it('returns 503 with searchSync false when the search sync rejects on upsert', async () => {
 		const env = makeUploadEnv((sql, args) => {
 			if (sql.includes('SELECT filename FROM speech_index WHERE filename = ?')) {
 				return { success: true, results: [] };
@@ -345,13 +345,20 @@ describe('syncSearchArtifacts error logging', () => {
 				markdown: '# Fail\n## A:\nhi'
 			})
 		});
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(true);
+		expect(json.searchSync).toBe(false);
 	});
 
-	it('logs but does not fail delete when the search sync rejects', async () => {
+	it('returns 503 with searchSync false when the search sync rejects on delete', async () => {
 		const env = makeUploadEnv((sql) => {
 			if (sql.includes('SELECT speaker_route_pathname FROM speech_speakers')) {
 				return { success: true, results: [] };
+			}
+			if (sql.includes('SELECT section_id FROM speech_content WHERE filename = ?')) {
+				return { success: true, results: [{ section_id: 1 }] };
 			}
 			if (sql.includes('SELECT COUNT(*) AS count')) return { success: true, results: [{ count: 0 }] };
 			return { success: true, results: [] };
@@ -361,8 +368,13 @@ describe('syncSearchArtifacts error logging', () => {
 			method: 'DELETE',
 			headers: { Authorization: 'Bearer token-audrey' }
 		});
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(503);
+		const json = await res.json() as { success: boolean; cachePurge: boolean; searchSync: boolean };
+		expect(json.success).toBe(true);
+		expect(json.cachePurge).toBe(true);
+		expect(json.searchSync).toBe(false);
 	});
+
 });
 
 describe('assignPatchedSections branches — many inserted sections', () => {

--- a/test/upload_markdown_post.spec.ts
+++ b/test/upload_markdown_post.spec.ts
@@ -128,7 +128,7 @@ describe('POST /api/upload_markdown — new speech creation', () => {
 
 		expect(res.status).toBe(200);
 		const json = (await res.json()) as { success: boolean; filename: string; sectionsCount: number };
-		expect(json).toEqual({ success: true, cachePurge: true, filename: 'new-speech', sectionsCount: 2 });
+		expect(json).toEqual({ success: true, cachePurge: true, searchSync: true, filename: 'new-speech', sectionsCount: 2 });
 
 		const indexInsert = env.__operations.find((s) => s.sql.startsWith('INSERT INTO speech_index'));
 		expect(indexInsert).toBeDefined();


### PR DESCRIPTION
## Summary

Search artifact sync is no longer silent.

- `syncSearchArtifactsAfterUpsert/Delete` → `Promise<boolean>`
- Response fields: `cachePurge` (R2+Workers) and `searchSync` (overlay/stats)
- HTTP **503** if either is false after D1 commit
- Callers can distinguish stale cache vs stale search

Closes #156.

## Test plan
- [x] typecheck
- [x] test:coverage 100%
- [ ] deploy