### PR TITLE
fix(ask): render raw HTML anchors as real links

### DIFF
--- a/public/static/speeches/js/pagefind-search.js
+++ b/public/static/speeches/js/pagefind-search.js
@@ -160,7 +160,27 @@
 		}
 	}
 
+
+
+	// Ask backend sometimes returns raw HTML anchors in otherwise-markdown text.
+	// Extract them before escapeHtml and re-inject sanitized <a> tags so labels
+	// cannot inject markdown link syntax (issue #141).
+	function extractAskInlineHtmlAnchors(text) {
+		var anchors = [];
+		var withPlaceholders = String(text || '').replace(
+			/<a\b[^>]*\bhref\s*=\s*(["'])([^"'>\s]+)\1[^>]*>([\s\S]*?)<\/a>/gi,
+			function (_m, _quote, href, label) {
+				var cleanLabel = String(label).replace(/<[^>]+>/g, '').trim() || href;
+				var id = anchors.length;
+				anchors.push({ href: href, label: cleanLabel });
+				return '\u0000ASKA' + id + '\u0000';
+			}
+		);
+		return { text: withPlaceholders, anchors: anchors };
+	}
+
 	function sanitizeHtml(html) {
+
 		var doc = new DOMParser().parseFromString(html, 'text/html');
 		var blocked = doc.body.querySelectorAll('script, iframe, object, embed, base, meta, link');
 		for (var i = 0; i < blocked.length; i++) blocked[i].remove();
@@ -253,9 +273,10 @@
 	}
 
 	function renderAskInlineMarkdown(text, hrefByIndex) {
-		var html = escapeHtml(text || '');
+		var extracted = extractAskInlineHtmlAnchors(text || '');
+		var html = escapeHtml(extracted.text);
 		html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-		html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+		html = html.replace(/(^|[^*])\*([^\*\n]+)\*/g, '$1<em>$2</em>');
 		html = html.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, function (_m, label, href) {
 			if (!isSafeHttpUrl(href)) return escapeHtml(label);
 			return '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(label) + '</a>';
@@ -267,6 +288,13 @@
 				return '<sup class="cite"><a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">[' + escapeHtml(num) + ']</a></sup>';
 			});
 		}
+		// Restore extracted HTML anchors as sanitized links (or plain text if unsafe).
+		html = html.replace(/\u0000ASKA(\d+)\u0000/g, function (_m, id) {
+			var item = extracted.anchors[Number(id)];
+			if (!item) return '';
+			if (!isSafeHttpUrl(item.href)) return escapeHtml(item.label);
+			return '<a href="' + escapeHtml(item.href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(item.label) + '</a>';
+		});
 		return html;
 	}
 

--- a/test/ask_inline_html_anchors.spec.ts
+++ b/test/ask_inline_html_anchors.spec.ts
@@ -83,8 +83,9 @@ describe('ask inline HTML anchors (issue #141)', () => {
 		const html = renderAskInlineMarkdown(
 			'<a href="https://archive.tw">click](https://evil.example)</a>'
 		);
+		// href must stay on archive.tw; label may still show the injection attempt as text
 		expect(html).toContain('href="https://archive.tw"');
-		expect(html).not.toContain('evil.example');
+		expect(html).not.toMatch(/href="[^"]*evil\.example/);
 		expect(html).toContain('click](https://evil.example)');
 	});
 });

--- a/test/ask_inline_html_anchors.spec.ts
+++ b/test/ask_inline_html_anchors.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+// Mirrors public/static/speeches/js/pagefind-search.js ask inline rendering
+// (static IIFE asset; keep logic in sync when changing either side).
+function isSafeHttpUrl(value: string): boolean {
+	if (/[\s"'<>]/.test(value) || /&(quot|#39|lt|gt);/i.test(value)) return false;
+	try {
+		const url = new URL(value);
+		return url.protocol === 'http:' || url.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+function escapeHtml(str: string): string {
+	return String(str)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+function extractAskInlineHtmlAnchors(text: string): {
+	text: string;
+	anchors: Array<{ href: string; label: string }>;
+} {
+	const anchors: Array<{ href: string; label: string }> = [];
+	const withPlaceholders = String(text || '').replace(
+		/<a\b[^>]*\bhref\s*=\s*(["'])([^"'>\s]+)\1[^>]*>([\s\S]*?)<\/a>/gi,
+		(_m, _quote: string, href: string, label: string) => {
+			const cleanLabel = String(label).replace(/<[^>]+>/g, '').trim() || href;
+			const id = anchors.length;
+			anchors.push({ href, label: cleanLabel });
+			return `\u0000ASKA${id}\u0000`;
+		}
+	);
+	return { text: withPlaceholders, anchors };
+}
+
+function renderAskInlineMarkdown(text: string): string {
+	const extracted = extractAskInlineHtmlAnchors(text || '');
+	let html = escapeHtml(extracted.text);
+	html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+	html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+	html = html.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, (_m, label: string, href: string) => {
+		if (!isSafeHttpUrl(href)) return escapeHtml(label);
+		return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`;
+	});
+	html = html.replace(/\u0000ASKA(\d+)\u0000/g, (_m, id: string) => {
+		const item = extracted.anchors[Number(id)];
+		if (!item) return '';
+		if (!isSafeHttpUrl(item.href)) return escapeHtml(item.label);
+		return `<a href="${escapeHtml(item.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.label)}</a>`;
+	});
+	return html;
+}
+
+describe('ask inline HTML anchors (issue #141)', () => {
+	it('renders raw HTML anchors as real links', () => {
+		const raw =
+			'您的問題超出了資料庫的範圍，逐字稿網站連結如下：' +
+			'<a href="https://archive.tw" rel="nofollow noreferrer noopener" target="_blank">https://archive.tw</a>';
+		const html = renderAskInlineMarkdown(raw);
+		expect(html).toContain('<a href="https://archive.tw"');
+		expect(html).toContain('>https://archive.tw</a>');
+		expect(html).not.toContain('&lt;a href');
+	});
+
+	it('keeps plain markdown links working', () => {
+		const html = renderAskInlineMarkdown('see [archive](https://archive.tw)');
+		expect(html).toBe(
+			'see <a href="https://archive.tw" target="_blank" rel="noopener noreferrer">archive</a>'
+		);
+	});
+
+	it('strips unsafe schemes instead of linking them', () => {
+		const html = renderAskInlineMarkdown('<a href="javascript:alert(1)">x</a>');
+		expect(html).toBe('x');
+		expect(html).not.toContain('javascript');
+	});
+
+	it('does not let anchor labels inject markdown link targets', () => {
+		const html = renderAskInlineMarkdown(
+			'<a href="https://archive.tw">click](https://evil.example)</a>'
+		);
+		expect(html).toContain('href="https://archive.tw"');
+		expect(html).not.toContain('evil.example');
+		expect(html).toContain('click](https://evil.example)');
+	});
+});

--- a/www/static/speeches/js/pagefind-search.js
+++ b/www/static/speeches/js/pagefind-search.js
@@ -160,7 +160,27 @@
 		}
 	}
 
+
+
+	// Ask backend sometimes returns raw HTML anchors in otherwise-markdown text.
+	// Extract them before escapeHtml and re-inject sanitized <a> tags so labels
+	// cannot inject markdown link syntax (issue #141).
+	function extractAskInlineHtmlAnchors(text) {
+		var anchors = [];
+		var withPlaceholders = String(text || '').replace(
+			/<a\b[^>]*\bhref\s*=\s*(["'])([^"'>\s]+)\1[^>]*>([\s\S]*?)<\/a>/gi,
+			function (_m, _quote, href, label) {
+				var cleanLabel = String(label).replace(/<[^>]+>/g, '').trim() || href;
+				var id = anchors.length;
+				anchors.push({ href: href, label: cleanLabel });
+				return '\u0000ASKA' + id + '\u0000';
+			}
+		);
+		return { text: withPlaceholders, anchors: anchors };
+	}
+
 	function sanitizeHtml(html) {
+
 		var doc = new DOMParser().parseFromString(html, 'text/html');
 		var blocked = doc.body.querySelectorAll('script, iframe, object, embed, base, meta, link');
 		for (var i = 0; i < blocked.length; i++) blocked[i].remove();
@@ -253,9 +273,10 @@
 	}
 
 	function renderAskInlineMarkdown(text, hrefByIndex) {
-		var html = escapeHtml(text || '');
+		var extracted = extractAskInlineHtmlAnchors(text || '');
+		var html = escapeHtml(extracted.text);
 		html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-		html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+		html = html.replace(/(^|[^*])\*([^\*\n]+)\*/g, '$1<em>$2</em>');
 		html = html.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, function (_m, label, href) {
 			if (!isSafeHttpUrl(href)) return escapeHtml(label);
 			return '<a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(label) + '</a>';
@@ -267,6 +288,13 @@
 				return '<sup class="cite"><a href="' + escapeHtml(href) + '" target="_blank" rel="noopener noreferrer">[' + escapeHtml(num) + ']</a></sup>';
 			});
 		}
+		// Restore extracted HTML anchors as sanitized links (or plain text if unsafe).
+		html = html.replace(/\u0000ASKA(\d+)\u0000/g, function (_m, id) {
+			var item = extracted.anchors[Number(id)];
+			if (!item) return '';
+			if (!isSafeHttpUrl(item.href)) return escapeHtml(item.label);
+			return '<a href="' + escapeHtml(item.href) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(item.label) + '</a>';
+		});
 		return html;
 	}
 


### PR DESCRIPTION
## Summary

Fixes #141: when the homepage ask answer is out-of-scope, the backend returns a raw HTML `<a href="https://archive.tw">…</a>` which was escaped and shown as tags.

### Fix
- Extract safe/unsafe HTML anchors before `escapeHtml`
- Re-inject sanitized `<a>` for `http(s)` only
- Labels cannot inject alternate markdown link targets

Closes #141.

## Test plan
- [x] unit tests for #141 cases
- [x] typecheck
- [ ] deploy + homepage ask out-of-scope question