### PR TITLE
fix(ask): cache-bust pagefind-search after HTML anchor fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const SEARCH_MAX_QUERY_LENGTH = 80;
 const SEARCH_DEFAULT_PAGE_SIZE = 20;
 const SEARCH_MAX_PAGE_SIZE = 50;
 const SEARCH_SPEAKER_LIMIT = 10;
-const PAGEFIND_SCRIPT = '<script src="/static/speeches/js/pagefind-search.js?v=au-fugu-11"></script>';
+const PAGEFIND_SCRIPT = '<script src="/static/speeches/js/pagefind-search.js?v=au-fugu-12"></script>';
 const TWITTER_WIDGETS_SCRIPT = '<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>';
 
 function hasTwitterEmbed(contents: Array<string | null | undefined>): boolean {


### PR DESCRIPTION
## Summary

Follow-up to #160 / #141: bump `pagefind-search.js?v=au-fugu-11` → `au-fugu-12` so clients do not keep the old escaped-anchor script.

Closes #141.

## Test plan
- [x] token bump in `src/index.ts`
- [ ] deploy