### PR TITLE
feat(admin): front-only purge_cache for Workers Cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -915,6 +915,13 @@ app.post('/api/purge_cache', async (c) => {
 	);
 	if (!authorized) return c.text('Forbidden', 403);
 
+	// Front-only: skip R2 wipe (slow/timeout) and just purge Workers Cache.
+	const frontOnly = new URL(c.req.url).searchParams.get('front_only') === '1';
+	if (frontOnly) {
+		await purgeWorkersCache({ purgeEverything: true });
+		return c.json({ frontOnly: true, purged: true });
+	}
+
 	const bucket = c.env.SPEECH_CACHE;
 	let deleted = 0;
 	let cursor: string | undefined;


### PR DESCRIPTION
## Summary

`POST /api/purge_cache` currently lists/deletes the whole R2 bucket before front purge and can time out. Add `?front_only=1` to call `purgeWorkersCache({ purgeEverything: true })` only.

Needed to refresh home HTML after script cache-bust deploys without a full R2 wipe.

## Test plan
- [x] code change
- [ ] deploy + authorized front_only purge
- [ ] verify `/` has `au-fugu-12`