### PR TITLE
fix(admin): return real purge result from front_only purge_cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -918,8 +918,11 @@ app.post('/api/purge_cache', async (c) => {
 	// Front-only: skip R2 wipe (slow/timeout) and just purge Workers Cache.
 	const frontOnly = new URL(c.req.url).searchParams.get('front_only') === '1';
 	if (frontOnly) {
-		await purgeWorkersCache({ purgeEverything: true });
-		return c.json({ frontOnly: true, purged: true });
+		const purged = await purgeWorkersCache({ purgeEverything: true });
+		return c.json(
+			{ frontOnly: true, purged },
+			purged ? 200 : 503
+		);
 	}
 
 	const bucket = c.env.SPEECH_CACHE;
@@ -934,8 +937,11 @@ app.post('/api/purge_cache', async (c) => {
 		}
 		cursor = list.truncated ? list.cursor : undefined;
 	} while (cursor);
-	await purgeWorkersCache({ purgeEverything: true });
-	return c.json({ deleted });
+	const purged = await purgeWorkersCache({ purgeEverything: true });
+	return c.json(
+		{ deleted, purged },
+		purged ? 200 : 503
+	);
 });
 
 app.post('/api/cleanup_old_cache', async (c) => {

--- a/test/cors_purge_cache.spec.ts
+++ b/test/cors_purge_cache.spec.ts
@@ -125,8 +125,9 @@ describe('POST /api/purge_cache', () => {
 		});
 
 		expect(res.status).toBe(200);
-		const body = (await res.json()) as { deleted: number };
+		const body = (await res.json()) as { deleted: number; purged: boolean };
 		expect(body.deleted).toBe(3);
+		expect(body.purged).toBe(true);
 		expect(env.__r2Store.size).toBe(0);
 	});
 
@@ -145,6 +146,20 @@ describe('POST /api/purge_cache', () => {
 		const env = createSimpleEnv();
 		const { res } = await request('/api/purge_cache', env, { method: 'POST' });
 		expect(res.status).toBe(403);
+	});
+
+	it('front_only skips R2 wipe and reports purge result', async () => {
+		const env = createSimpleEnv();
+		env.__r2Store.set('keep-me', { body: 'x' });
+		const { res } = await request('/api/purge_cache?front_only=1', env, {
+			method: 'POST',
+			headers: { Authorization: 'Bearer token-audrey' }
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { frontOnly: boolean; purged: boolean };
+		expect(body.frontOnly).toBe(true);
+		expect(body.purged).toBe(true);
+		expect(env.__r2Store.size).toBe(1);
 	});
 });
 


### PR DESCRIPTION
## Summary

`POST /api/purge_cache?front_only=1` always returned `{purged:true}`. It now uses `purgeWorkersCache`'s boolean and returns **503** / `purged:false` on failure. Full purge also reports `purged`.

## Test plan
- [x] unit tests for front_only
- [ ] deploy + purge + bare `/` shows au-fugu-12