### PR TITLE
fix(deploy): lift stale migration block, enforce R2-upload-before-flip

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
 	"private": true,
 	"packageManager": "bun@1.3.14",
 	"scripts": {
-		"deploy": "echo 'BLOCKED on techdebt/vp-lemmascript-migration: prod deploy disabled during migration. Use: bun run deploy:staging' && exit 1",
-		"deploy:assets": "echo 'BLOCKED on techdebt/vp-lemmascript-migration: prod deploy disabled during migration. Use: bun run deploy:staging:assets' && exit 1",
-		"deploy:search": "echo 'BLOCKED on techdebt/vp-lemmascript-migration: prod deploy disabled during migration. Use: bun run deploy:staging' && exit 1",
+		"deploy": "bun run deploy:search",
+		"deploy:assets": "bun run preflight:deploy && bun run build:cache-version && vite build && npx wrangler deploy && bun run verify:deploy",
+		"deploy:search": "bun run preflight:deploy && bun run build:cache-version && vite build && ALLOW_PROD_R2=1 bun run build:search && npx wrangler deploy && bun run verify:deploy",
 		"deploy:staging": "bun run build:cache-version && CLOUDFLARE_ENV=staging vite build && SEARCH_R2_BUCKETS=sayit-speech-cache-staging bun run build:search && npx wrangler deploy --env staging && VERIFY_URL=https://sayit-hono-staging.audreyt.workers.dev/version DEPLOY_RETRY_HINT='CLOUDFLARE_ENV=staging vite build && npx wrangler deploy --env staging' bun run verify:deploy",
 		"deploy:staging:assets": "bun run build:cache-version && CLOUDFLARE_ENV=staging vite build && npx wrangler deploy --env staging && VERIFY_URL=https://sayit-hono-staging.audreyt.workers.dev/version bun run verify:deploy",
 		"dev": "vite dev",

--- a/scripts/build-search-index.ts
+++ b/scripts/build-search-index.ts
@@ -412,6 +412,13 @@ async function buildSearchIndex() {
 		if (uploadedToR2) {
 			await Promise.all([outputPath, outputBrPath, runtimeManifestPath, statsPath].map(removeIfExists));
 			console.log('[build-search] Removed R2-served generated files from www/ before Wrangler asset upload');
+		} else {
+			// A caller chaining this with `&&` (deploy:search, deploy:staging) must
+			// not proceed to `wrangler deploy` on a half-uploaded index — that
+			// would flip the worker to code expecting R2 keys that were never
+			// written. Fail the whole script instead of warning and continuing.
+			process.exitCode = 1;
+			throw new Error('[build-search] Aborting: one or more R2 uploads failed (see errors above).');
 		}
 	}
 }


### PR DESCRIPTION
Closes #167

第一次跑正式 `bun run deploy` 時發現的兩個部署管線缺口,已修好並在 production 上驗證過(`archive.tw/version` = `v-e73a111`,stats/search-index/sections-dump 都是 200,search 有真實結果,OG 圖片正常,upload_markdown 認證仍正確擋掉未帶 token 的請求)。詳見 commit message。

另外發現但本次不處理:今天 11:58Z 左右 production 曾被一個「history rewrite 前」的 5 天前孤兒 commit(`a3f25e4`)重新部署過一次——內容經核對其實已經在目前 main 的等價 commit(PR #143 的 `98ce8db`/`1e128ad`)裡,所以沒有真的 rollback 到任何功能,但部署來源(哪台機器/哪個腳本)還沒查到,之後有機會可能再次覆蓋。這件事你比我更有能力查(我看不到本機以外的環境),麻煩空的時候看一下。